### PR TITLE
初回インストールとシェル起動時のバグを修正

### DIFF
--- a/.chezmoiscripts/run_once_after_01_create_XDG_directories.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_01_create_XDG_directories.sh.tmpl
@@ -1,6 +1,11 @@
-#! /bin/zsh
+#!/bin/sh
+set -eu
 
-mkdir -p "$XDG_CONFIG_HOME"
-mkdir -p "$XDG_DATA_HOME"
-mkdir -p "$XDG_STATE_HOME"
-mkdir -p "$XDG_CACHE_HOME"
+# 初回インストール時はまだ ~/.zshenv が読まれていないため XDG 変数が未定義。
+# 環境変数に頼らず、chezmoi が知っている HOME からパスを組み立てる。
+home={{ .chezmoi.homeDir | quote }}
+
+mkdir -p "${XDG_CONFIG_HOME:-$home/.config}"
+mkdir -p "${XDG_DATA_HOME:-$home/.local/share}"
+mkdir -p "${XDG_STATE_HOME:-$home/.local/state}"
+mkdir -p "${XDG_CACHE_HOME:-$home/.cache}"

--- a/.chezmoiscripts/run_once_after_01_create_XDG_directories.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_01_create_XDG_directories.sh.tmpl
@@ -2,10 +2,12 @@
 set -eu
 
 # 初回インストール時はまだ ~/.zshenv が読まれていないため XDG 変数が未定義。
-# 環境変数に頼らず、chezmoi が知っている HOME からパスを組み立てる。
-home={{ .chezmoi.homeDir | quote }}
+# 環境変数に頼らず、chezmoi が知っている適用先からパスを組み立てる。
+# ここで作るのは「適用先」のディレクトリ群なので homeDir ではなく destDir を使う
+# (--destination で試し適用したときに実ホームを触らないようにするため)。
+dest={{ .chezmoi.destDir | squote }}
 
-mkdir -p "${XDG_CONFIG_HOME:-$home/.config}"
-mkdir -p "${XDG_DATA_HOME:-$home/.local/share}"
-mkdir -p "${XDG_STATE_HOME:-$home/.local/state}"
-mkdir -p "${XDG_CACHE_HOME:-$home/.cache}"
+mkdir -p "${XDG_CONFIG_HOME:-$dest/.config}"
+mkdir -p "${XDG_DATA_HOME:-$dest/.local/share}"
+mkdir -p "${XDG_STATE_HOME:-$dest/.local/state}"
+mkdir -p "${XDG_CACHE_HOME:-$dest/.cache}"

--- a/.chezmoiscripts/run_once_after_02_excute_brew_bundle.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_02_excute_brew_bundle.sh.tmpl
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 
 if ! command -v brew >/dev/null 2>&1; then
     echo "brew command not found 😱"

--- a/.chezmoiscripts/run_once_before_01_install_go.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_01_install_go.sh.tmpl
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 GO_VERSION=1.23.1
 
 if command -v go >/dev/null 2>&1

--- a/.chezmoiscripts/run_once_before_01_install_go.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_01_install_go.sh.tmpl
@@ -1,7 +1,7 @@
 #! /bin/sh
 GO_VERSION=1.23.1
 
-if command -v go &> /dev/null
+if command -v go >/dev/null 2>&1
 then
   echo "Go is already installed. 🙆‍♂️"
   exit 0

--- a/.chezmoiscripts/run_once_before_02-install-homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_02-install-homebrew.sh.tmpl
@@ -1,4 +1,4 @@
-#! /bin/sh
+#!/bin/sh
 echo "brew path: {{ .brew.path }}"
 
 if command -v brew >/dev/null 2>&1

--- a/.chezmoiscripts/run_once_before_02-install-homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_02-install-homebrew.sh.tmpl
@@ -1,7 +1,7 @@
 #! /bin/sh
 echo "brew path: {{ .brew.path }}"
 
-if command -v brew &> /dev/null
+if command -v brew >/dev/null 2>&1
 then
   echo "Homebrew is already installed."
   exit 0

--- a/dot_config/zsh/dot_zshenv.tmpl
+++ b/dot_config/zsh/dot_zshenv.tmpl
@@ -3,7 +3,7 @@ unsetopt GLOBAL_RCS
 export EDITOR="nvim"
 
 ### Ruby ###
-export IRMRC="$XDG_CONFIG_HOME/irb/irbrc"
+export IRBRC="$XDG_CONFIG_HOME/irb/irbrc"
 
 export BUNDLE_USER_HOME="$XDG_CONFIG_HOME/bundle"
 export BUNDLE_USER_CACHE="$XDG_CACHE_HOME/bundle"

--- a/dot_config/zsh/sheldon/plugins.toml
+++ b/dot_config/zsh/sheldon/plugins.toml
@@ -17,6 +17,8 @@ post = "zsh-defer source $ZDOTDIR/hooks/zeno-post.zsh"
 
 [plugins.compinit]
 inline = """
+# ディレクトリが無いと compinit は dump を黙って作らず、毎回フルスキャンになる
+mkdir -p "$XDG_STATE_HOME/zsh"
 autoload -Uz compinit
 zsh-defer -a -t0.01 compinit -d "$XDG_STATE_HOME/zsh/zcompdump"
 """

--- a/dot_config/zsh/sheldon/plugins.toml
+++ b/dot_config/zsh/sheldon/plugins.toml
@@ -17,8 +17,10 @@ post = "zsh-defer source $ZDOTDIR/hooks/zeno-post.zsh"
 
 [plugins.compinit]
 inline = """
-# ディレクトリが無いと compinit は dump を黙って作らず、毎回フルスキャンになる
-mkdir -p "$XDG_STATE_HOME/zsh"
+# ディレクトリが無いと compinit は dump を黙って作らず、毎回フルスキャンになる。
+# 2 回目以降の起動で fork しないよう組み込みの [[ -d ]] でガードする。
+: "${XDG_STATE_HOME:=$HOME/.local/state}"
+[[ -d $XDG_STATE_HOME/zsh ]] || mkdir -p $XDG_STATE_HOME/zsh
 autoload -Uz compinit
 zsh-defer -a -t0.01 compinit -d "$XDG_STATE_HOME/zsh/zcompdump"
 """

--- a/dot_config/zsh/sync.zsh.tmpl
+++ b/dot_config/zsh/sync.zsh.tmpl
@@ -1,6 +1,9 @@
 ### locale ###
 export LANG="en_US.UTF-8"
 
+# 通常は ~/.zshenv が定義済み。未定義でも HISTFILE などが / 直下を指さないようにする
+: "${XDG_STATE_HOME:=$HOME/.local/state}"
+
 ### uniq path ###
 typeset -gU PATH path
 typeset -gU FPATH fpath


### PR DESCRIPTION
## 概要

chezmoi 環境の調査で見つかったバグのうち、挙動を壊さない最小の修正のみを行う。

## 修正内容

### 1. compinit の dump が作られていなかった (`dot_config/zsh/sheldon/plugins.toml`)

`compinit -d "$XDG_STATE_HOME/zsh/zcompdump"` を指定しているが `~/.local/state/zsh/` が存在せず、compinit は**エラーを出さずに dump の書き出しを諦めていた**。結果として毎回フルスキャンで補完を初期化していた。dump 先を作ってから compinit するようにした。

レビュー指摘を受け、変数未定義時に `/zsh` を掘らないようフォールバックを入れ、2 回目以降の起動で fork しないよう組み込みの `[[ -d ]]` でガードしている。`HISTFILE` も同じ変数に依存しているため、`dot_config/zsh/sync.zsh.tmpl` 側にも同じフォールバックを置いた。

検証:
```
$ env -u XDG_STATE_HOME HOME=/tmp/fakehome zsh -c ': "${XDG_STATE_HOME:=$HOME/.local/state}"
  [[ -d $XDG_STATE_HOME/zsh ]] || mkdir -p $XDG_STATE_HOME/zsh
  autoload -Uz compinit; compinit -d "$XDG_STATE_HOME/zsh/zcompdump"'
$ find /tmp/fakehome -name zcompdump
/tmp/fakehome/.local/state/zsh/zcompdump   # 修正前は何も作られない
```

### 2. XDG ディレクトリ作成スクリプトが初回インストールで機能しない

`.chezmoiscripts/run_once_after_01_create_XDG_directories.sh.tmpl` は `$XDG_CONFIG_HOME` 等の環境変数を参照していたが、curl 一発の初回インストールでは `~/.zshenv` がまだ読まれておらず未定義。`mkdir -p ""` になっていた。chezmoi が知っている適用先からパスを組み立て、環境変数があればそちらを優先する形に変更。

ここで作るのは適用先のディレクトリ群なので、`.chezmoi.homeDir` ではなく `.chezmoi.destDir` を使う (`--destination` での試し適用時に実ホームを触らないため)。`quote` ではなく `squote` を使い、パスに `$` やバッククォートが含まれても sh 側で展開されないようにしている。

```
$ chezmoi execute-template --destination /tmp/chezmoi-dryrun
destDir=/tmp/chezmoi-dryrun   homeDir=/Users/matazou
```

併せて shebang を `/bin/zsh` から `/bin/sh` に変更 (zsh が入っていない Ubuntu の初回実行で落ちるため)。ついでに他 3 スクリプトの `#! /bin/sh` も `#!/bin/sh` に揃えた。

### 3. `#!/bin/sh` のスクリプトで `&>` を使用

`run_once_before_01_install_go` と `run_once_before_02-install-homebrew` の `command -v ... &> /dev/null` を `>/dev/null 2>&1` に修正。

**当初この PR では「dash では構文エラーになる」と書いていたが、これは誤り。** 実際には構文エラーにはならず、**条件が常に真になる**。`command -v go &` (バックグラウンド実行、ステータス 0) と `> /dev/null` (リダイレクトのみのコマンド、0) に分解され、`if` は後者の 0 を見るため。

```
$ dash -c 'if command -v 存在しないコマンド &> /dev/null; then echo TRUE; else echo FALSE; fi'
TRUE
$ dash -n -c 'command -v go &> /dev/null'   # 構文エラーにはならない
$
```

つまり macOS では `/bin/sh` が bash なので意図通り動いていたが、**Ubuntu では Go / Homebrew のインストールが無言でスキップされ、成功したように見えていた**。当初の想定より影響は深刻だった。

### 4. `IRMRC` の誤記

`dot_config/zsh/dot_zshenv.tmpl` の `IRMRC` を `IRBRC` に修正。IRB は XDG パスを自力で探すため実害は出ていなかった。

## 動作確認

- 全 `.chezmoiscripts/*.tmpl` の展開 + **`dash -n`** による構文チェック → 全て pass
- XDG 変数を全て unset した状態で dash 実行 → エラーなく完走
- `XDG_STATE_HOME` 未定義/定義済みの両方でガードが正しく解決することを確認 (未定義なら `$HOME/.local/state`、定義済みなら上書きしない)
- `sheldon source` の出力と `sync.zsh` の展開結果を `zsh -n` でチェック → pass

再実行される `run_once_` スクリプトはいずれも冪等 (`mkdir -p` / インストール済みなら早期 exit) なので、適用は安全。

## 別 PR に切り出した指摘

`dot_config/irb/irbrc` の `File.join(ENV['XDG_STATE_HOME'], ...)` が変数未設定時に `TypeError` になる件は #14 で対応する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)