### PR TITLE
irbrc の XDG_STATE_HOME 未設定時の TypeError を修正

### DIFF
--- a/dot_config/irb/irbrc
+++ b/dot_config/irb/irbrc
@@ -1,1 +1,4 @@
-IRB.conf[:HISTORY_FILE] = File.join(ENV['XDG_STATE_HOME'], '.irb_history')
+IRB.conf[:HISTORY_FILE] = File.join(
+  ENV.fetch('XDG_STATE_HOME', File.expand_path('~/.local/state')),
+  '.irb_history'
+)

--- a/dot_config/irb/irbrc
+++ b/dot_config/irb/irbrc
@@ -1,4 +1,4 @@
-IRB.conf[:HISTORY_FILE] = File.join(
-  ENV.fetch('XDG_STATE_HOME', File.expand_path('~/.local/state')),
-  '.irb_history'
-)
+xdg_state_home = ENV['XDG_STATE_HOME']
+xdg_state_home = File.expand_path('~/.local/state') if xdg_state_home.nil? || xdg_state_home.empty?
+
+IRB.conf[:HISTORY_FILE] = File.join(xdg_state_home, '.irb_history')


### PR DESCRIPTION
Closes #14

## 概要

`dot_config/irb/irbrc` が `ENV['XDG_STATE_HOME']` をそのまま `File.join` に渡していたため、`XDG_STATE_HOME` 未設定の環境では `File.join(nil, ...)` となり `TypeError` になっていた。IRB 側が rescue するため致命的ではないが、履歴ファイルの設定が効かなくなる。

`ENV.fetch` でデフォルト値 `~/.local/state` を与えるように修正した。

## 確認

`XDG_STATE_HOME` を外した状態で警告なくパスが出力されることを確認:

```sh
echo 'puts IRB.conf[:HISTORY_FILE]' | env -u XDG_STATE_HOME IRBRC="$PWD/dot_config/irb/irbrc" irb --noprompt --noverbose
# => /Users/matazou/.local/state/.irb_history
```

(issue に記載の `irb -e ...` は、macOS システム同梱の irb 1.0.0 が `-e` 非対応のため上記の形で確認している)

🤖 Generated with [Claude Code](https://claude.com/claude-code)