### PR TITLE
fast-syntax-highlighting の取得元を zdharma-continuum に変更

### DIFF
--- a/dot_config/zsh/sheldon/plugins.toml
+++ b/dot_config/zsh/sheldon/plugins.toml
@@ -32,7 +32,7 @@ github = "Aloxaf/fzf-tab"
 apply = ["defer"]
 
 [plugins.fast-syntax-highlighting]
-github = "zdharma/fast-syntax-highlighting"
+github = "zdharma-continuum/fast-syntax-highlighting"
 apply = ["defer"]
 
 [plugins.zsh-autosuggestions]


### PR DESCRIPTION
## 概要

`dot_config/zsh/sheldon/plugins.toml` の `fast-syntax-highlighting` の取得元を `zdharma/fast-syntax-highlighting` から `zdharma-continuum/fast-syntax-highlighting` に変更する。

`zdharma` org は 2021 年に元の作者がアカウントごと削除したもので、現在の URL は当時とは別の主体が保持している。シェル起動時に毎回 source されるコードの取得元としては望ましくない。メンテナンスが継続しているのは `zdharma-continuum` の方 (最終コミット 2025-07-16 `3d574cc`)。

## 検証

scratchpad の隔離環境 (`SHELDON_CONFIG_DIR` / `SHELDON_DATA_DIR` を差し替え) で実施。実環境の `~/.local/share/sheldon` は未変更。

- `sheldon lock --update` が成功することを確認
- **プラグインファイル名は変わっている** (`F-Sy-H.plugin.zsh` → `fast-syntax-highlighting.plugin.zsh`)。ただし sheldon のデフォルト match が `{{ name }}.plugin.zsh` を最優先で拾い、プラグイン名が `fast-syntax-highlighting` なのでそのままヒットする。`match` の指定は不要で、`sheldon source` の出力でも新しいファイル名が source されることを確認
- pty 上で `zsh -i` を起動し、zsh-defer のロード後に実際にキー入力してハイライトが効くことを確認
  - `echo hello /etc/hosts` → `echo` が緑 (有効なコマンド)、`/etc/hosts` がマゼンタ (存在するパス)
  - `nosuchcommand42 hello` → 太字赤 (存在しないコマンド)
  - 起動時の出力にエラーなし

## マージ後の手動作業

手元には旧 org の clone が残っているため削除が必要。

```sh
chezmoi apply && rm -rf ~/.local/share/sheldon/repos/github.com/zdharma && sheldon lock --update
```

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)