### PR TITLE
パッケージ一覧を .chezmoidata に移す

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -2,40 +2,18 @@
 
 progress = true
 
-[data.brew.packages]
-  common = [
-    "chezmoi",
-    "sheldon",
-    "deno",
-    "mise",
-    "bat",
-    "fd",
-    "fzf",
-    "git",
-    "ghq",
-    "starship",
-    "neovim",
-    "jq",
-    "eza",
-    "ripgrep"
-  ]
-  mac = [
-    "borders"
-  ]
-  cask.common = [
-   "1password",
-   "1password-cli",
-   "font-plemol-jp",
-  ]
+# NOTE: パッケージ一覧の本体は .chezmoidata/packages.yaml にある。
+# ここには promptBool の結果に依存して .chezmoidata に置けないものだけを残す。
+[data.brew.packages.cask]
   {{ if promptBool "Do you want to install external casks" -}}
-  cask.external = [
+  external = [
     "alt-tab",
     "cleanshot",
     "deepl",
     "raycast",
   ]
   {{ else -}}
-  cask.external = []
+  external = []
   {{ end -}}
 
 {{- if eq .chezmoi.os "linux" }}

--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -1,0 +1,24 @@
+brew:
+  packages:
+    common:
+      - chezmoi
+      - sheldon
+      - deno
+      - mise
+      - bat
+      - fd
+      - fzf
+      - git
+      - ghq
+      - starship
+      - neovim
+      - jq
+      - eza
+      - ripgrep
+    mac:
+      - borders
+    cask:
+      common:
+        - 1password
+        - 1password-cli
+        - font-plemol-jp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,12 +28,18 @@ chezmoi data              # テンプレートで参照できる変数の一覧
 
 ## テンプレートのデータソース
 
-`.chezmoi.toml.tmpl` が生成する `~/.config/chezmoi/chezmoi.toml` がテンプレート変数の実体。ここが 2 つの役割を持つ:
+テンプレート変数の実体は 2 箇所にあり、chezmoi が両者を再帰的にマージする。
 
-1. `[data.brew.packages]` — インストールするパッケージ一覧 (`common` / `mac` / `cask.common` / `cask.external`)。`cask.external` は `chezmoi init` 時の `promptBool` で入れるか選ばせる。パッケージを追加する場合はここを編集する。
-2. `[data.brew] path` — OS/アーキテクチャごとの brew パス (`/opt/homebrew`, `/usr/local`, `/home/linuxbrew/.linuxbrew`)。`sync.zsh.tmpl` の `eval "$({{ .brew.path }} shellenv)"` などがこれを参照する。
+1. `.chezmoidata/packages.yaml` — インストールするパッケージ一覧 (`brew.packages` の `common` / `mac` / `cask.common`)。**パッケージを追加する場合はここを編集する。**
+2. `.chezmoi.toml.tmpl` が生成する `~/.config/chezmoi/chezmoi.toml` — `promptBool` や OS 判定に依存して `.chezmoidata` に置けないもの:
+   - `[data.brew.packages.cask] external` — `chezmoi init` 時の `promptBool` で入れるか選ばせる
+   - `[data.brew] path` — OS/アーキテクチャごとの brew パス (`/opt/homebrew`, `/usr/local`, `/home/linuxbrew/.linuxbrew`)。`sync.zsh.tmpl` の `eval "$({{ .brew.path }} shellenv)"` などがこれを参照する
 
-**`.chezmoi.toml.tmpl` を変更しても既存環境の `chezmoi.toml` は自動更新されない。** 反映には `chezmoi init` の再実行が必要。
+`.chezmoidata/` は chezmoi が毎回自動で読むので、1 を編集した場合は `chezmoi apply` するだけで反映される。
+
+**一方 `.chezmoi.toml.tmpl` (2) を変更しても既存環境の `chezmoi.toml` は自動更新されない。** 反映には `chezmoi init` の再実行が必要。
+
+なお **`chezmoi.toml` の `data` は `.chezmoidata` より優先される**。両者で同じキーを定義すると `.chezmoidata` 側がエラーにならず静かに無視されるので、キーを重複させないこと。
 
 ## zsh 設定の構造
 

--- a/dot_config/zsh/dot_zshenv.tmpl
+++ b/dot_config/zsh/dot_zshenv.tmpl
@@ -29,9 +29,6 @@ export AQUA_ROOT_DIR="$XDG_DATA_HOME/aqua"
 export AQUA_GLOBAL_CONFIG="$XDG_CONFIG_HOME/aqua/global.yaml"
 export AQUA_PROGRESS_BAR=true
 
-### brew ###
-export HOMEBREW_BUNDLE_FILE="$XDG_CONFIG_HOME/brew/Brewfile"
-
 ### sheldon ###
 export SHELDON_CONFIG_DIR="$ZDOTDIR/sheldon"
 


### PR DESCRIPTION
Closes #6

## 変更内容

### `.chezmoidata` への移行

パッケージ一覧が `.chezmoi.toml.tmpl` にあるため、1 つ追加するだけで `chezmoi init` の再実行が必要だった。`.chezmoidata` は chezmoi が毎回自動で読むので、この制約が消える。

- `.chezmoidata/packages.yaml` を新設 (`common` / `mac` / `cask.common`)
- `.chezmoi.toml.tmpl` には `.chezmoidata` に置けないものだけ残す
  - `[data.brew.packages.cask] external` — `promptBool` の結果に依存する
  - `[data.brew] path` — OS/アーキ判定
- 参照名 `.brew.packages.common` 等は変わらないため `.chezmoiscripts/run_once_after_02_excute_brew_bundle.sh.tmpl` は無変更

### `HOMEBREW_BUNDLE_FILE` の削除

指し先の `$XDG_CONFIG_HOME/brew/Brewfile` が存在せず、裸で `brew bundle` を打つと失敗する。Brewfile を実体として持たない方針なので設定自体が不要。論点が独立しているのでコミットを分けている。

### CLAUDE.md の更新

データソースが 2 箇所になったことを反映。あわせて **`chezmoi.toml` の `data` は `.chezmoidata` より優先される**点を注意書きとして追加した (キーが重複すると `.chezmoidata` 側がエラーにならず静かに無視されるため)。

## 検証

隔離した HOME / XDG 環境で実際に `chezmoi init` を通して確認した。

- brew bundle スクリプトの展開結果が変更前と**バイト単位で一致**
- `.chezmoidata` にパッケージを 1 つ追加 → **`chezmoi init` 再実行なしで反映**されること (本 issue の受け入れ条件)
- `promptBool` = false のケースで cask が 3 件 (external が空) になること
- 生成される `chezmoi.toml` が有効な TOML としてパースされること

## マージ後に必要な作業

**既存環境で一度だけ `chezmoi init` の再実行が必要。** 現在の `~/.config/chezmoi/chezmoi.toml` に残っている `common` / `mac` / `cask.common` が `.chezmoidata` を上書きし続けるため (詳細は https://github.com/kazu-2020/dotfiles/issues/6#issuecomment-5235841970)。

```sh
chezmoi init --promptBool "Do you want to install external casks=true"
```

これ以降はパッケージ追加時の `chezmoi init` は不要になる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
