### PR TITLE
fzf-tab に必要な補完 zstyle を追加

### DIFF
--- a/dot_config/zsh/sheldon/plugins.toml
+++ b/dot_config/zsh/sheldon/plugins.toml
@@ -21,6 +21,17 @@ inline = """
 # 2 回目以降の起動で fork しないよう組み込みの [[ -d ]] でガードする。
 : "${XDG_STATE_HOME:=$HOME/.local/state}"
 [[ -d $XDG_STATE_HOME/zsh ]] || mkdir -p $XDG_STATE_HOME/zsh
+
+# 補完の設定は compinit より前に済ませておく。
+# fzf-tab はグループ名に compadd の説明文字列 ($expl) を使うので、
+# descriptions format が無いと $expl が空になりグループ表示が機能しない。
+zstyle ':completion:*:descriptions' format '[%d]'
+# fzf-tab 自体は menu zstyle を参照しない。現状 menu select も MENU_COMPLETE も
+# 設定していないので実質 no-op だが、将来入れたときに標準メニューと二重にならない保険。
+zstyle ':completion:*' menu no
+# cd 補完時にディレクトリの中身をプレビューする
+zstyle ':fzf-tab:complete:cd:*' fzf-preview 'eza --icons --tree --level=1 --color=always $realpath'
+
 autoload -Uz compinit
 zsh-defer -a -t0.01 compinit -d "$XDG_STATE_HOME/zsh/zcompdump"
 """


### PR DESCRIPTION
## 概要

`Aloxaf/fzf-tab` を読み込んでいるのに `zstyle` 設定が無い件 (#10) の対応。

compinit より前に評価する必要があるため、`plugins.toml` の `[plugins.compinit]` inline 内に置いた。この inline は `zsh-defer` されず同期実行されるので、deferred な compinit より確実に先に評価される。

## 追加した設定

```zsh
zstyle ':completion:*:descriptions' format '[%d]'
zstyle ':completion:*' menu no
zstyle ':fzf-tab:complete:cd:*' fzf-preview 'eza --icons --tree --level=1 --color=always $realpath'
```

## #10 の記述からの変更点

実装前に fzf-tab と zsh のソースを確認したところ、issue の前提が一部成立していなかったので内容を調整した。

**`descriptions format` — 唯一、実挙動が変わる設定**

`fzf-tab.zsh:51` の `[[ -n $expl ]] && _ftb_groups+=$expl` が、compadd の説明文字列をグループ名に使っている。`format` 未設定だと `$expl` が空になりグループ表示が機能しない。

**`menu no` — この構成では no-op。コメントを実態に合わせた**

- fzf-tab は `menu` zstyle を一切参照していない（`fzf-tab.zsh` 内の `menu` 出現箇所はコメント1件とウィジェット名のみ）
- リポジトリ内に `menu select` を設定している箇所は無く、`MENU_COMPLETE` も未設定

つまり「標準メニューと競合している」状態は発生していない。`/usr/share/zsh/5.9/functions/_main_complete:296` で `compstate[insert]=unambiguous` が選ばれる既定の挙動に既になっている。無害なので将来の保険として残しつつ、「必須」ではない旨をコメントに書いた。

**`matcher-list` — 削除**

fzf-tab と無関係な一般の補完設定で、このスコープに含める理由が無いため落とした。

## 検証

- TOML パース、および inline 部分の `zsh -n` が通ること
- `eza` / `fzf` はどちらも `.chezmoi.toml.tmpl` の `brew.packages.common` に含まれており、プレビューの依存を満たすこと
- `m:{a-z}={A-Za-z}` を落としたことで、sheldon (Tera) のテンプレート構文と衝突しうる記述は無くなった

## 関連

対応中に、zeno と fzf-tab が TAB のバインドを奪い合っている別の問題が見つかったので #17 に切り出した。こちらでは扱わない。

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)
