### PR TITLE
TAB の補完を fzf-tab に寄せる

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,8 @@ XDG 準拠のため `ZDOTDIR` を `~/.config/zsh` に寄せている。読み込
 - `hooks/async.zsh.tmpl` — エイリアスと mise 有効化。sheldon の `[plugins.async]` から遅延 source される
 - `hooks/zeno-pre.zsh` / `zeno-post.zsh` — zeno の環境変数とキーバインド。プラグインの `hooks.pre` / `hooks.post` から呼ばれる
 
+**TAB (`^i`) の補完 UI は fzf-tab に寄せる方針**。zeno は `config.yml` の `snippets:` を使うスニペット展開と履歴選択・ghq cd に限定して使い、`zeno-completion` は bind しない。両方を bind すると `zsh-defer` の FIFO 実行で後から読まれた方が勝つため、読み込み順に依存した壊れ方をする。
+
 `sheldon/plugins.toml` の `[templates] defer` 内の `{{ }}` は sheldon (Tera) のテンプレート構文であり、chezmoi のものではない。このファイルは `.tmpl` ではないので chezmoi は展開しないが、`.tmpl` 化する場合は `{{` のエスケープが必要になる。
 
 `hooks/manager.zsh.tmpl` は現状どこからも読み込まれていない (内容は `async.zsh.tmpl` と重複)。

--- a/dot_config/zsh/hooks/zeno-post.zsh
+++ b/dot_config/zsh/hooks/zeno-post.zsh
@@ -1,7 +1,10 @@
 if [[ -n $ZENO_LOADED ]]; then
   bindkey ' '  zeno-auto-snippet
   bindkey '^m' zeno-auto-snippet-and-accept-line
-  bindkey '^i' zeno-completion
+  # TAB (^i) は fzf-tab に寄せるので zeno-completion は bind しない。
+  # ここで bind すると sheldon の読み込み順次第で fzf-tab と奪い合いになる
+  # (現状は fzf-tab が後勝ちしているだけで、順序が変わると壊れる)。
+  # zeno は snippets: を使うスニペット展開と履歴選択に限定して使う。
   bindkey '^x '  zeno-insert-space
   bindkey '^x^m' accept-line
   bindkey '^x^z' zeno-toggle-auto-snippet


### PR DESCRIPTION
Closes #17

## 背景

TAB (`^I`) のバインドを zeno と fzf-tab が奪い合っていた。`plugins.toml` の記述順が zeno → compinit → fzf-tab で、いずれも `zsh-defer` の FIFO 実行なので fzf-tab が後勝ちしており、`zeno-completion` は TAB から到達不能だった。

fzf-tab は読み込み時点の `^I` バインドをフォールバック先 (`_ftb_orig_widget`) として記録するため、実質使えない `zeno-completion` がフォールバックに刺さった状態にもなっていた。

## 判断

**fzf-tab に寄せる。** 理由:

- `dot_config/zeno/config.yml` の `completions:` は丸ごとコメントアウトされており、`zeno-completion` に固有の設定資産が無い
- fzf-tab は zsh 標準の補完定義をそのまま使うので設定ゼロで全コマンドに効く。#19 で入れた zstyle 群 (グループ表示、`cd` の eza プレビュー) もそのまま活きる
- zeno のスニペット展開・履歴選択・ghq cd は `zeno-completion` とは別ウィジェット・別設定なので影響を受けない

## 変更

- `dot_config/zsh/hooks/zeno-post.zsh` — `bindkey '^i' zeno-completion` を削除し、bind しない理由をコメントで明記
- `CLAUDE.md` — 補完 UI の方針を zsh 設定の構造セクションに追記

## 検証

実際の fzf-tab を読み込んで `bindkey` を確認した:

```
zeno-post 後 ^I : expand-or-complete
fzf-tab 後 ^I  : fzf-tab-complete
_ftb_orig_widget: expand-or-complete
^r              : zeno-history-selection
space           : zeno-auto-snippet
```

- TAB は fzf-tab に確定
- `_ftb_orig_widget` が標準の `expand-or-complete` に戻った
- スニペット展開 (スペース) と履歴選択 (`^r`) は無傷

🤖 Generated with [Claude Code](https://claude.com/claude-code)