### PR TITLE
失敗したコマンドを zsh 履歴ファイルに残さない

### DIFF
--- a/dot_config/zsh/sync.zsh.tmpl
+++ b/dot_config/zsh/sync.zsh.tmpl
@@ -43,6 +43,30 @@ setopt hist_save_no_dups
 setopt hist_verify
 setopt inc_append_history_time
 
+# 失敗したコマンドを履歴ファイルに残さない。
+# zshaddhistory の時点では終了ステータスが分からないため、return 2 で
+# 内部履歴のみに保存してファイル書き込みを保留し、precmd で成功時だけ書き込む
+autoload -Uz add-zsh-hook
+
+__defer_hist_write() {
+    # 先頭スペースの行は hist_ignore_space に任せる
+    [[ $1 == \ * ]] && return 0
+    typeset -g __deferred_hist_line="${1%%$'\n'}"
+    return 2
+}
+
+__save_hist_if_ok() {
+    local last_status=$?
+    # ^C (130) や ^Z (148) による中断は失敗扱いにしない
+    if [[ -n $__deferred_hist_line ]] && (( last_status == 0 || last_status == 130 || last_status == 148 )); then
+        print -sr -- "$__deferred_hist_line"
+    fi
+    __deferred_hist_line=
+}
+
+add-zsh-hook zshaddhistory __defer_hist_write
+add-zsh-hook precmd __save_hist_if_ok
+
 # cd options
 setopt auto_cd
 setopt auto_pushd

--- a/dot_config/zsh/sync.zsh.tmpl
+++ b/dot_config/zsh/sync.zsh.tmpl
@@ -41,25 +41,38 @@ setopt hist_ignore_space
 setopt hist_reduce_blanks
 setopt hist_save_no_dups
 setopt hist_verify
-setopt inc_append_history_time
 
 # 失敗したコマンドを履歴ファイルに残さない。
-# zshaddhistory の時点では終了ステータスが分からないため、return 2 で
-# 内部履歴のみに保存してファイル書き込みを保留し、precmd で成功時だけ書き込む
+# zshaddhistory の時点では終了ステータスが分からないため、いったん保存を保留し
+# (return 1)、precmd で成功していた場合だけ内部履歴へ入れて fc -AI で即時追記する。
+# inc_append_history(_time) は fc -AI との二重書き込みで重複が出るため使わない。
+#
+# 制約:
+# - extended_history のタイムスタンプは終了時刻になり、経過時間は常に 0 になる
+# - 失敗したコマンドを ↑ で呼び出せるのは直後の 1 回だけ (打ち直し用)
+# - この 2 つの hook が唯一の zshaddhistory 消費者である前提。行を破棄する
+#   フィルタ hook を追加する場合は __defer_hist_write 側にも同じ条件を足すこと
 autoload -Uz add-zsh-hook
 
 __defer_hist_write() {
     # 先頭スペースの行は hist_ignore_space に任せる
-    [[ $1 == \ * ]] && return 0
+    [[ -o hist_ignore_space && $1 == \ * ]] && return 0
     typeset -g __deferred_hist_line="${1%%$'\n'}"
-    return 2
+    return 1
 }
 
 __save_hist_if_ok() {
     local last_status=$?
-    # ^C (130) や ^Z (148) による中断は失敗扱いにしない
-    if [[ -n $__deferred_hist_line ]] && (( last_status == 0 || last_status == 130 || last_status == 148 )); then
-        print -sr -- "$__deferred_hist_line"
+    # シグナルで中断されたコマンド (^C や ^Z など: 128 超) は失敗扱いにしない
+    if [[ -n $__deferred_hist_line ]] && (( last_status == 0 || last_status > 128 )); then
+        local line="$__deferred_hist_line"
+        # print -S は hist_reduce_blanks を通らないため単一行のみ自前で正規化する
+        # (多行は ${(z)} が改行を ';' に書き換えてしまうので対象外)
+        if [[ -o hist_reduce_blanks && $line != *$'\n'* ]]; then
+            line="${(j: :)${(z)line}}"
+        fi
+        print -Sr -- "$line"
+        fc -AI
     fi
     __deferred_hist_line=
 }


### PR DESCRIPTION
## 概要

終了ステータスが 0 以外のコマンドを `zsh_history` ファイルに書き込まないようにする。

## 実装

`zshaddhistory` の時点では終了ステータスが分からないため、2 段階で処理する:

1. `zshaddhistory` で `return 1` — 保存をいったん保留する
2. `precmd` で終了ステータスを確認し、成功時のみ `print -Sr` で内部履歴へ入れ、`fc -AI` で HISTFILE に即時追記する

`inc_append_history_time` は `fc -AI` との二重書き込みで重複が発生するため撤去した。

## 挙動

- シグナルによる中断 (`^C`=130, macOS の `^Z`=146 などステータス 128 超) は失敗扱いにしない
- 失敗したコマンドは ↑ で直後に 1 回だけ呼び出せる (打ち直し用)。それ以降は内部履歴からも消える
- 成功コマンドは precmd 時点でファイルに反映されるため、zeno の `^r` や tmux 別ペインからも即座に見える。セッション最後のコマンドも `exit` 前に書き込み済みで消えない
- 先頭スペースの行は従来どおり `hist_ignore_space` に任せる (`[[ -o hist_ignore_space ]]` でゲート)
- `hist_reduce_blanks` 相当の空白正規化は単一行のみ自前で適用 (引用符内の空白は保持)

## 制約

- `extended_history` のタイムスタンプは終了時刻になり、経過時間は常に 0 で記録される
- この hook が唯一の `zshaddhistory` 消費者である前提 (フィルタ hook を追加する場合は `__defer_hist_write` 側にも条件を足す。コメントに明記済み)

## 検証

テスト用 zsh 環境 (zsh 5.9 / macOS) で以下を確認:

- `false` や存在しないパスへの `ls` がファイルに残らない
- ステータス 146 (macOS の `^Z` 相当) のコマンドは残る
- `echo foo bar` → `echo !$` の履歴展開が動作し、`fc -l` のイベント番号に欠番がない
- セッション途中の HISTFILE に直前の成功コマンドが即時反映され、重複がない
- `exit` 直前のコマンドがファイルに残る。複数セッションの追記で他セッションのエントリを壊さない
- 多行コマンド (for ループ等) が正しく保存・復元される
- `chezmoi execute-template` の展開結果が `zsh -n` を通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)