### PR TITLE
external cask の質問を promptBoolOnce にする

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -3,9 +3,13 @@
 progress = true
 
 # NOTE: パッケージ一覧の本体は .chezmoidata/packages.yaml にある。
-# ここには promptBool の結果に依存して .chezmoidata に置けないものだけを残す。
+# ここには prompt の結果に依存して .chezmoidata に置けないものだけを残す。
+# installExternal は promptBoolOnce の参照先。この値を書き出しておくことで
+# chezmoi init を再実行しても前回の回答を引き継ぎ、再質問されない。
+{{- $installExternal := promptBoolOnce . "brew.packages.cask.installExternal" "Do you want to install external casks" }}
 [data.brew.packages.cask]
-  {{ if promptBool "Do you want to install external casks" -}}
+  installExternal = {{ $installExternal }}
+  {{ if $installExternal -}}
   external = [
     "alt-tab",
     "cleanshot",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,8 +32,8 @@ chezmoi data              # テンプレートで参照できる変数の一覧
 テンプレート変数の実体は 2 箇所にあり、chezmoi が両者を再帰的にマージする。
 
 1. `.chezmoidata/packages.yaml` — インストールするパッケージ一覧 (`brew.packages` の `common` / `mac` / `cask.common`)。**パッケージを追加する場合はここを編集する。**
-2. `.chezmoi.toml.tmpl` が生成する `~/.config/chezmoi/chezmoi.toml` — `promptBool` や OS 判定に依存して `.chezmoidata` に置けないもの:
-   - `[data.brew.packages.cask] external` — `chezmoi init` 時の `promptBool` で入れるか選ばせる
+2. `.chezmoi.toml.tmpl` が生成する `~/.config/chezmoi/chezmoi.toml` — prompt や OS 判定に依存して `.chezmoidata` に置けないもの:
+   - `[data.brew.packages.cask] external` / `installExternal` — `chezmoi init` 時の `promptBoolOnce` で入れるか選ばせる。回答は `installExternal` として書き出され、次回以降の `chezmoi init` はそれを引き継ぐので再質問されない (質問し直したい場合は `chezmoi.toml` からこのキーを消す)
    - `[data.brew] path` — OS/アーキテクチャごとの brew パス (`/opt/homebrew`, `/usr/local`, `/home/linuxbrew/.linuxbrew`)。`sync.zsh.tmpl` の `eval "$({{ .brew.path }} shellenv)"` などがこれを参照する
 
 `.chezmoidata/` は chezmoi が毎回自動で読むので、1 を編集した場合は `chezmoi apply` するだけで反映される。


### PR DESCRIPTION
Closes #26

## 概要

`.chezmoi.toml.tmpl` の external cask の分岐で使っていた `promptBool` を `promptBoolOnce` に置き換え、`chezmoi init` を再実行しても再質問されないようにした。

あわせて、参照先となる `installExternal` を生成後の `chezmoi.toml` にも書き出すようにしている。`promptBoolOnce` は「既存 config の指定パスに値があればそれを使う」という動作なので、値を書き出さないと毎回質問される挙動は変わらないため。

```
{{- $installExternal := promptBoolOnce . "brew.packages.cask.installExternal" "Do you want to install external casks" }}
[data.brew.packages.cask]
  installExternal = {{ $installExternal }}
```

CLAUDE.md のデータソースの説明も追随させた。

## 動作確認

`chezmoi execute-template --init` で以下を確認済み。

- 初回 (回答 true / false) — それぞれ `installExternal` と `external` が期待どおり出力される
- 2 回目 (前回の回答が入った config を `--config` で渡し `--promptBool` を指定しない) — 質問なしで前回値どおりに展開される

## 注意

`.chezmoi.toml.tmpl` の変更は既存環境に自動反映されないため、反映には `chezmoi init` の再実行が必要。その 1 回は `installExternal` がまだ無いので質問されるが、以降は引き継がれる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)