### PR TITLE
CI の追加: chezmoi execute-template の両 OS 検証と shellcheck

### DIFF
--- a/.chezmoiscripts/run_once_before_02_install_homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_02_install_homebrew.sh.tmpl
@@ -17,13 +17,15 @@ REQUIRED_PACKAGES="build-essential procps curl file git"
 MISSING_PACKAGES=""
 
 for pkg in $REQUIRED_PACKAGES; do
-    if ! dpkg -l | grep -qw $pkg; then
+    if ! dpkg -l | grep -qw "$pkg"; then
         MISSING_PACKAGES="$MISSING_PACKAGES $pkg"
     fi
 done
 
 if [ ! -z "$MISSING_PACKAGES" ]; then
     echo "Installing missing packages: $MISSING_PACKAGES"
+    # パッケージ名のリストなので意図的に単語分割させる
+    # shellcheck disable=SC2086
     sudo apt-get install -y $MISSING_PACKAGES
 fi
 {{- end }}

--- a/.chezmoiscripts/run_once_before_02_install_homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_02_install_homebrew.sh.tmpl
@@ -17,7 +17,7 @@ REQUIRED_PACKAGES="build-essential procps curl file git"
 MISSING_PACKAGES=""
 
 for pkg in $REQUIRED_PACKAGES; do
-    if ! dpkg -l | grep -qw "$pkg"; then
+    if ! dpkg-query -W -f='${Status}' "$pkg" 2>/dev/null | grep -q "ok installed"; then
         MISSING_PACKAGES="$MISSING_PACKAGES $pkg"
     fi
 done

--- a/.chezmoiscripts/run_once_before_02_install_homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_02_install_homebrew.sh.tmpl
@@ -22,7 +22,7 @@ for pkg in $REQUIRED_PACKAGES; do
     fi
 done
 
-if [ ! -z "$MISSING_PACKAGES" ]; then
+if [ -n "$MISSING_PACKAGES" ]; then
     echo "Installing missing packages: $MISSING_PACKAGES"
     # パッケージ名のリストなので意図的に単語分割させる
     # shellcheck disable=SC2086

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,85 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  # macOS (arm64 / amd64) と Ubuntu の実ランナー上で chezmoi のテンプレート展開を検証する。
+  # .chezmoi.os / .chezmoi.arch は execute-template で偽装できないため、OS ごとに実機で回す。
+  verify:
+    name: verify (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest # linux / amd64
+          - macos-latest # darwin / arm64 (Apple Silicon)
+          - macos-15-intel # darwin / amd64 (Intel)
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install chezmoi
+        run: |
+          sh -c "$(curl -fsLS get.chezmoi.io)" -- -b "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      # Ubuntu ランナーには shellcheck がプリインストールされている
+      - name: Install shellcheck (macOS)
+        if: runner.os == 'macOS'
+        run: brew install shellcheck
+
+      # .chezmoi.toml.tmpl を promptBool の両分岐で展開できることを確認しつつ、
+      # 後続の execute-template が参照する chezmoi.toml (brew.path など) を生成する
+      - name: Verify .chezmoi.toml.tmpl and generate config
+        run: |
+          for v in true false; do
+            chezmoi execute-template --init \
+              --promptBool "Do you want to install external casks=$v" \
+              < .chezmoi.toml.tmpl > /dev/null
+            echo "OK: .chezmoi.toml.tmpl (external casks: $v)"
+          done
+          chezmoi init --source "$GITHUB_WORKSPACE" \
+            --promptBool "Do you want to install external casks=true"
+
+      - name: Verify all templates render
+        run: |
+          rc=0
+          while IFS= read -r f; do
+            if chezmoi execute-template < "$f" > /dev/null; then
+              echo "OK: $f"
+            else
+              echo "NG: $f"
+              rc=1
+            fi
+          done < <(find . -name '*.tmpl' ! -name '.chezmoi.toml.tmpl' ! -path './.git/*' | sort)
+          exit "$rc"
+
+      - name: Shellcheck rendered .chezmoiscripts
+        run: |
+          tmpdir="$(mktemp -d)"
+          for f in .chezmoiscripts/*.sh.tmpl; do
+            out="$tmpdir/$(basename "${f%.tmpl}")"
+            chezmoi execute-template < "$f" > "$out"
+            echo "rendered: $f"
+          done
+          shellcheck "$tmpdir"/*.sh
+
+  yaml-syntax:
+    name: yaml syntax (.chezmoidata)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate .chezmoidata/*.yaml
+        run: |
+          python3 -c "import yaml" 2>/dev/null || python3 -m pip install --user --quiet pyyaml
+          for f in .chezmoidata/*.yaml; do
+            python3 -c "import sys, yaml; yaml.safe_load(open(sys.argv[1]))" "$f"
+            echo "OK: $f"
+          done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,19 +34,32 @@ jobs:
         if: runner.os == 'macOS'
         run: brew install shellcheck
 
-      # .chezmoi.toml.tmpl を promptBool の両分岐で展開できることを確認しつつ、
-      # 後続の execute-template が参照する chezmoi.toml (brew.path など) を生成する
+      # .chezmoi.toml.tmpl を promptBool の両分岐で展開し、分岐が展開結果に反映されて
+      # いることをアサートする (--promptBool はプロンプト文言が一致しないとエラーに
+      # ならず黙って false になるため、展開が成功するだけでは検証にならない)。
+      # あわせて後続の execute-template が参照する chezmoi.toml (brew.path など) を生成する
       - name: Verify .chezmoi.toml.tmpl and generate config
         run: |
+          tmpcfg="$(mktemp -d)"
           for v in true false; do
-            chezmoi execute-template --init \
+            chezmoi execute-template --init --source "$GITHUB_WORKSPACE" \
               --promptBool "Do you want to install external casks=$v" \
-              < .chezmoi.toml.tmpl > /dev/null
-            echo "OK: .chezmoi.toml.tmpl (external casks: $v)"
+              < .chezmoi.toml.tmpl > "$tmpcfg/$v.toml"
           done
+          grep -qF 'external = []' "$tmpcfg/false.toml" || {
+            echo "NG: promptBool=false で external casks が空リストにならない" >&2
+            exit 1
+          }
+          if grep -qF 'external = []' "$tmpcfg/true.toml"; then
+            echo "NG: promptBool=true が展開結果に反映されていない (プロンプト文言の不一致?)" >&2
+            exit 1
+          fi
+          echo "OK: .chezmoi.toml.tmpl (promptBool 両分岐)"
           chezmoi init --source "$GITHUB_WORKSPACE" \
             --promptBool "Do you want to install external casks=true"
 
+      # .chezmoiignore / .chezmoiremove は拡張子に関係なく常にテンプレートとして
+      # 解釈されるため、*.tmpl と同様に検証対象へ含める
       - name: Verify all templates render
         run: |
           rc=0
@@ -57,7 +70,8 @@ jobs:
               echo "NG: $f"
               rc=1
             fi
-          done < <(find . -name '*.tmpl' ! -name '.chezmoi.toml.tmpl' ! -path './.git/*' | sort)
+          done < <(find . \( -name '*.tmpl' -o -name '.chezmoiignore' -o -name '.chezmoiremove' \) \
+                     ! -name '.chezmoi.toml.tmpl' ! -path './.git/*' | sort)
           exit "$rc"
 
       - name: Shellcheck rendered .chezmoiscripts
@@ -70,16 +84,30 @@ jobs:
           done
           shellcheck "$tmpdir"/*.sh
 
-  yaml-syntax:
-    name: yaml syntax (.chezmoidata)
+  data-syntax:
+    name: data syntax (.chezmoidata)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Validate .chezmoidata/*.yaml
+      # chezmoi は .chezmoidata/ から .yaml / .yml / .json / .toml をすべて読むので
+      # 全形式を検証する。pip の --break-system-packages は PEP 668 (externally-managed)
+      # な system Python へのフォールバックインストール用
+      - name: Validate .chezmoidata data files
         run: |
-          python3 -c "import yaml" 2>/dev/null || python3 -m pip install --user --quiet pyyaml
-          for f in .chezmoidata/*.yaml; do
-            python3 -c "import sys, yaml; yaml.safe_load(open(sys.argv[1]))" "$f"
+          python3 -c "import yaml" 2>/dev/null \
+            || python3 -m pip install --user --quiet --break-system-packages pyyaml
+          shopt -s nullglob
+          files=(.chezmoidata/*.yaml .chezmoidata/*.yml .chezmoidata/*.json .chezmoidata/*.toml)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "NG: .chezmoidata に検証対象のデータファイルがない" >&2
+            exit 1
+          fi
+          for f in "${files[@]}"; do
+            case "$f" in
+              *.yaml | *.yml) python3 -c "import sys, yaml; yaml.safe_load(open(sys.argv[1]))" "$f" ;;
+              *.json) python3 -c "import sys, json; json.load(open(sys.argv[1]))" "$f" ;;
+              *.toml) python3 -c "import sys, tomllib; tomllib.load(open(sys.argv[1], 'rb'))" "$f" ;;
+            esac
             echo "OK: $f"
           done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         run: |
           rc=0
           while IFS= read -r f; do
-            if chezmoi execute-template < "$f" > /dev/null; then
+            if chezmoi execute-template --source "$GITHUB_WORKSPACE" < "$f" > /dev/null; then
               echo "OK: $f"
             else
               echo "NG: $f"
@@ -65,7 +65,7 @@ jobs:
           tmpdir="$(mktemp -d)"
           for f in .chezmoiscripts/*.sh.tmpl; do
             out="$tmpdir/$(basename "${f%.tmpl}")"
-            chezmoi execute-template < "$f" > "$out"
+            chezmoi execute-template --source "$GITHUB_WORKSPACE" < "$f" > "$out"
             echo "rendered: $f"
           done
           shellcheck "$tmpdir"/*.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## リポジトリの性質
 
-[chezmoi](https://www.chezmoi.io/) で管理する dotfiles のソースディレクトリ。ビルドは存在しないが、CI (`.github/workflows/ci.yml`) が macOS (arm64/amd64) と Ubuntu の各ランナーで全 `.tmpl` の `chezmoi execute-template` 検証・展開後スクリプトの shellcheck・`.chezmoidata` の YAML 構文チェックを行う。対象 OS は macOS (Intel / Apple Silicon) と Ubuntu で、OS 差分は Go テンプレートで吸収する。
+[chezmoi](https://www.chezmoi.io/) で管理する dotfiles のソースディレクトリ。ビルドは存在しないが、CI (`.github/workflows/ci.yml`) が macOS (arm64/amd64) と Ubuntu の各ランナーで全テンプレート (`*.tmpl` と `.chezmoiignore` / `.chezmoiremove`) の `chezmoi execute-template` 検証・展開後スクリプトの shellcheck・`.chezmoidata` のデータ構文チェックを行う。対象 OS は macOS (Intel / Apple Silicon) と Ubuntu で、OS 差分は Go テンプレートで吸収する。
 
 このディレクトリ自体が chezmoi のソースディレクトリ (`~/.local/share/chezmoi`) なので、ここでファイルを編集しても `chezmoi apply` するまでホームディレクトリには反映されない。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## リポジトリの性質
 
-[chezmoi](https://www.chezmoi.io/) で管理する dotfiles のソースディレクトリ。ビルド・テスト・リントは存在しない。対象 OS は macOS (Intel / Apple Silicon) と Ubuntu で、OS 差分は Go テンプレートで吸収する。
+[chezmoi](https://www.chezmoi.io/) で管理する dotfiles のソースディレクトリ。ビルドは存在しないが、CI (`.github/workflows/ci.yml`) が macOS (arm64/amd64) と Ubuntu の各ランナーで全 `.tmpl` の `chezmoi execute-template` 検証・展開後スクリプトの shellcheck・`.chezmoidata` の YAML 構文チェックを行う。対象 OS は macOS (Intel / Apple Silicon) と Ubuntu で、OS 差分は Go テンプレートで吸収する。
 
 このディレクトリ自体が chezmoi のソースディレクトリ (`~/.local/share/chezmoi`) なので、ここでファイルを編集しても `chezmoi apply` するまでホームディレクトリには反映されない。
 


### PR DESCRIPTION
Closes #38

## 概要

GitHub Actions で issue #38 の 3 点を自動化する CI (`.github/workflows/ci.yml`) を追加しました。

### 1. テンプレート検証 (両 OS)

`.chezmoi.os` / `.chezmoi.arch` は `execute-template` で偽装できないため、実ランナーのマトリクスで検証します:

- `ubuntu-latest` (linux/amd64)
- `macos-latest` (darwin/arm64, Apple Silicon)
- `macos-15-intel` (darwin/amd64, Intel)

各ランナーで:
- `.chezmoi.toml.tmpl` を `--init --promptBool` の **true/false 両分岐**で展開検証
- `chezmoi init --source` で config を生成 (`.brew.path` など config 由来の変数を後続に供給)
- 残り全 `.tmpl` を `chezmoi execute-template` で展開し、エラーがないことを確認

### 2. shellcheck

`.chezmoiscripts/*.sh.tmpl` をテンプレート展開してから shellcheck をかけます。Linux 展開時のみ現れる分岐で SC2086 が 2 件検出されたため、あわせて修正しました:

- `grep -qw $pkg` → `grep -qw "$pkg"`
- `apt-get install -y $MISSING_PACKAGES` は意図的な単語分割のため `# shellcheck disable=SC2086` を付与

### 3. YAML 構文チェック

`.chezmoidata/*.yaml` を PyYAML の `safe_load` で検証します。

## 検証

- ローカル (macOS arm64) で全テンプレートの `execute-template` 展開と展開後スクリプトの shellcheck が通ることを確認
- Linux 相当の展開結果を手動再現して shellcheck が通ることを確認
- ワークフローは actionlint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)