### PR TITLE
irb 履歴を XDG_STATE_HOME/irb/history へ移す

### DIFF
--- a/.chezmoiscripts/run_once_after_03_migrate_irb_history.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_03_migrate_irb_history.sh.tmpl
@@ -1,0 +1,27 @@
+#!/bin/sh
+set -eu
+
+# irb の履歴ファイルを $XDG_STATE_HOME/.irb_history から
+# $XDG_STATE_HOME/irb/history へ移す (隠しファイルをやめてツール別に切り直した)。
+# 初回インストール時はまだ ~/.zshenv が読まれていないため XDG 変数が未定義。
+# 環境変数に頼らず、chezmoi が知っている適用先からパスを組み立てる。
+dest={{ .chezmoi.destDir | squote }}
+
+state="${XDG_STATE_HOME:-$dest/.local/state}"
+old="$state/.irb_history"
+new="$state/irb/history"
+
+# 旧ファイルがなければ何もしない (新規環境ではこれが常態)
+[ -f "$old" ] || exit 0
+
+# 移行先が既にあるなら上書きせず旧ファイルを残す (履歴を失わないため)
+if [ -e "$new" ]; then
+  echo "skip: $new が既にあるため $old は移動しない" >&2
+  exit 0
+fi
+
+mkdir -p "$(dirname "$new")"
+chmod 700 "$(dirname "$new")"
+mv "$old" "$new"
+chmod 600 "$new"
+echo "moved: $old -> $new"

--- a/dot_config/irb/irbrc
+++ b/dot_config/irb/irbrc
@@ -1,4 +1,11 @@
+require 'fileutils'
+
 xdg_state_home = ENV['XDG_STATE_HOME']
 xdg_state_home = File.expand_path('~/.local/state') if xdg_state_home.nil? || xdg_state_home.empty?
 
-IRB.conf[:HISTORY_FILE] = File.join(xdg_state_home, '.irb_history')
+# irb は履歴ファイルの親ディレクトリを作らないので、ここで用意しておく。
+# 履歴には秘匿値が混ざりうるため 0700 にする (履歴ファイル自体は irb が 0600 で作る)。
+history_dir = File.join(xdg_state_home, 'irb')
+FileUtils.mkdir_p(history_dir, mode: 0o700)
+
+IRB.conf[:HISTORY_FILE] = File.join(history_dir, 'history')


### PR DESCRIPTION
Closes #37

## 変更内容

`dot_config/irb/irbrc` の履歴ファイルを `$XDG_STATE_HOME/.irb_history` から `$XDG_STATE_HOME/irb/history` へ変更した。XDG state 配下なので隠しファイルにする必要がなく、issue で挙がっていたツール別サブディレクトリを切る形を採用している。

irb は履歴ファイルの親ディレクトリを作らない (`irb/ext/save-history.rb` は `File.open(history_file, 'w', 0600)` するだけ) ので、irbrc 側で `FileUtils.mkdir_p` する。履歴には秘匿値が混ざりうるためディレクトリは 0700 にした。

既存環境の旧ファイル移行用に `.chezmoiscripts/run_once_after_03_migrate_irb_history.sh.tmpl` を追加した。既存の 01/02 と同じく、初回適用時は XDG 変数が未定義なので `.chezmoi.destDir` からパスを組み立てている。移行先が既にある場合は上書きせず旧ファイルを残す (履歴を失わないため)。

`.chezmoiremove` は使っていない。あれは削除なので、履歴を残したい今回の用途には合わない。

## 検証

ローカルで実行済み:

- `chezmoi execute-template` でのレンダリング成功、レンダリング後の `.chezmoiscripts/*.sh` 全体が shellcheck パス
- `ruby -c dot_config/irb/irbrc` 構文 OK、`IRB.run_config` の実機実行で `$XDG_STATE_HOME/irb/history` がセットされ、ディレクトリが `drwx------` で作られることを確認
- 移行スクリプトを一時ディレクトリで 3 パターン実行 — 旧ファイルあり (移動 + 内容保持 + 0600) / 旧ファイルなし (何もせず exit 0) / 移行先と衝突 (skip して旧ファイル温存)

🤖 Generated with [Claude Code](https://claude.com/claude-code)