### PR TITLE
nvim 設定の小さな修正 (vim.loop deprecated / vim.opt.encoding 不要)

### DIFF
--- a/dot_config/nvim/lua/config.lua
+++ b/dot_config/nvim/lua/config.lua
@@ -1,5 +1,4 @@
 vim.scriptencoding = "utf-8"
-vim.opt.encoding = "utf-8"
 vim.opt.fileencoding = "utf-8"
 vim.opt.helplang = "ja,en"
 

--- a/dot_config/nvim/lua/lazy-nvim.lua
+++ b/dot_config/nvim/lua/lazy-nvim.lua
@@ -1,5 +1,5 @@
 local lazypath = vim.fn.stdpath("data") .. "/lazy/lazy.nvim"
-if not vim.loop.fs_stat(lazypath) then
+if not vim.uv.fs_stat(lazypath) then
   vim.fn.system({
     "git",
     "clone",


### PR DESCRIPTION
Closes #35

## 変更内容

- `dot_config/nvim/lua/lazy-nvim.lua`: `vim.loop.fs_stat` → `vim.uv.fs_stat` (lazy.nvim 公式ブートストラップの最新版に合わせる)
- `dot_config/nvim/lua/config.lua`: `vim.opt.encoding = "utf-8"` を削除 (Neovim では encoding は常に utf-8 固定)

## 確認したこと

- リポジトリ内に他の `vim.loop` / `vim.opt.encoding` の使用箇所がないことを grep で確認
- `vim.uv` は Neovim 0.10 以降で利用可能 (手元は v0.12.4)
- 両ファイルを `loadfile` で構文チェック済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)