### PR TITLE
bordersrc のインデントをタブに統一し不要なコメント行を削除

### DIFF
--- a/dot_config/borders/executable_bordersrc
+++ b/dot_config/borders/executable_bordersrc
@@ -4,8 +4,7 @@ options=(
 	style=round
 	width=6.0
 	hidpi=on
-        active_color=0xffffa500
-	#active_color=0xffe2e2e3
+	active_color=0xffffa500
 	inactive_color=0xff414550
 )
 


### PR DESCRIPTION
Closes #36

## 変更内容

- `dot_config/borders/executable_bordersrc` の `active_color` 行がスペースインデントだったのをタブに統一（他の行に合わせた）
- コメントアウトされた旧 `active_color=0xffe2e2e3` を削除

## 確認

- `shellcheck dot_config/borders/executable_bordersrc` が通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)