### PR TITLE
zeno-insert-snippet を ESC 単独から ^x^s へ移す

### DIFF
--- a/dot_config/zsh/hooks/zeno-post.zsh
+++ b/dot_config/zsh/hooks/zeno-post.zsh
@@ -10,7 +10,11 @@ if [[ -n $ZENO_LOADED ]]; then
   bindkey '^x^z' zeno-toggle-auto-snippet
 
   bindkey '^r' zeno-history-selection
-  bindkey '^[' zeno-insert-snippet
+  # ESC 単独 (^[) には bind しない。矢印キーなどのエスケープシーケンス
+  # (^[[A など) と prefix が衝突し、KEYTIMEOUT 分の入力遅延や ESC 連打時の
+  # 誤発動を招くため、^x プレフィックス側に寄せている
+  # (^s は sync.zsh の no_flow_control で解放済み)。
+  bindkey '^x^s' zeno-insert-snippet
   bindkey '^]' zeno-ghq-cd
 fi
 


### PR DESCRIPTION
Closes #34

## 背景

`bindkey '^[' zeno-insert-snippet` は ESC 単独へのバインドで、矢印キーなどのエスケープシーケンス (`^[[A` など) と prefix が衝突する。KEYTIMEOUT 由来の入力遅延や、ESC 連打時の誤発動の温床になる。

## 変更

`zeno-insert-snippet` のバインドを `^[` から `^x^s` に移し、理由をコメントで残した。

## `^x^s` を選んだ根拠

- 既存の zeno バインドが `^x` プレフィックス系 (`^x `, `^x^m`, `^x^z`) に寄っており、`^x^s` は空き
- zsh の emacs キーマップでも `^X^S` はデフォルト未割り当て
- `^s` はフロー制御 (XOFF) に食われる懸念があるが、`sync.zsh.tmpl` で `setopt no_flow_control` 済みなので問題なし

## 確認

- `zsh -n dot_config/zsh/hooks/zeno-post.zsh` → OK
- `bindkey "^x^s" ...` が実際に登録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)