### PR TITLE
zsh: HISTSIZE を SAVEHIST に揃える

### DIFF
--- a/dot_config/zsh/sync.zsh.tmpl
+++ b/dot_config/zsh/sync.zsh.tmpl
@@ -31,7 +31,8 @@ eval "$({{ .brew.path  }} shellenv)"
 
 ### history ###
 export HISTFILE="$XDG_STATE_HOME/zsh_history"
-export HISTSIZE=10000
+# HISTSIZE < SAVEHIST だと古い履歴がメモリに載らず Ctrl-R で引けないので揃える
+export HISTSIZE=100000
 export SAVEHIST=100000
 
 setopt extended_history


### PR DESCRIPTION
## 概要

`HISTSIZE=10000` < `SAVEHIST=100000` の逆転を解消し、両方 `100000` に揃えました。

ファイルには 10 万件保存される一方でメモリには 1 万件しか読み込まれないため、古い履歴が Ctrl-R などで引けない状態でした。

## issue の 2 点目について

`setopt hist_ignore_dups` の重複は、issue 起票後の `a8f4b26`「不要ファイルと重複設定を掃除する」で既に解消済みでした。現在 history 関連の setopt は `sync.zsh.tmpl` の 1 箇所にまとまっており (現在は `hist_ignore_all_dups` を使用)、追加作業は不要と判断しています。

## 確認

- `chezmoi execute-template < dot_config/zsh/sync.zsh.tmpl` で展開結果を確認

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)