### PR TITLE
chezmoi.toml.tmpl の brew.path 分岐を 1 セクションに集約

### DIFF
--- a/.chezmoi.toml.tmpl
+++ b/.chezmoi.toml.tmpl
@@ -9,34 +9,27 @@ progress = true
 {{- $installExternal := promptBoolOnce . "brew.packages.cask.installExternal" "Do you want to install external casks" }}
 [data.brew.packages.cask]
   installExternal = {{ $installExternal }}
-  {{ if $installExternal -}}
+{{- if $installExternal }}
   external = [
     "alt-tab",
     "cleanshot",
     "deepl",
     "raycast",
   ]
-  {{ else -}}
+{{- else }}
   external = []
-  {{ end -}}
-
-{{- if eq .chezmoi.os "linux" }}
-[data.brew]
-  path = "/home/linuxbrew/.linuxbrew/bin/brew"
 {{- end }}
-
-{{- if (and (eq .chezmoi.os "darwin") (eq .chezmoi.arch "arm64")) }}
-# Apple シリコン
-[data.brew]
-  path = "/opt/homebrew/bin/brew"
+{{/* linux は linuxbrew、macOS は Apple シリコン (arm64) と Intel (amd64) で brew のパスが異なる */ -}}
+{{- $brewPath := "" -}}
+{{- if eq .chezmoi.os "linux" -}}
+{{-   $brewPath = "/home/linuxbrew/.linuxbrew/bin/brew" -}}
+{{- else if eq .chezmoi.arch "arm64" -}}
+{{-   $brewPath = "/opt/homebrew/bin/brew" -}}
+{{- else -}}
+{{-   $brewPath = "/usr/local/bin/brew" -}}
 {{- end }}
-
-{{- if (and (eq .chezmoi.os "darwin") (eq .chezmoi.arch "amd64")) }}
-# Intel Mac
 [data.brew]
-  path = "/usr/local/bin/brew"
-{{- end }}
-  
+  path = {{ $brewPath | quote }}
 
 [edit]
 {{ if lookPath "nvim" }}


### PR DESCRIPTION
Closes #33

## 変更内容

1. **`[data.brew]` の 3 重分岐を 1 つに集約** — OS/arch ごとに同じセクションを 3 回書いていたのを、`$brewPath` に代入してからセクションを 1 回だけ出力する形にした (issue の修正案どおり)。
2. **行末空白の除去** — 空白のみの行を削除。あわせて `{{ if }}` / `{{ else }}` / `{{ end }}` のインデント (`  {{ ... -}}`) が展開後の `chezmoi.toml` に空白だけの行を残していたため `{{- ... }}` に修正した。

## 検証

4 通りの os/arch すべてでパスが正しいことを確認 (`.chezmoi.os` / `.chezmoi.arch` を変数に差し替えたテンプレートで展開):

| os/arch | path |
| --- | --- |
| linux (amd64/arm64) | `/home/linuxbrew/.linuxbrew/bin/brew` |
| darwin arm64 | `/opt/homebrew/bin/brew` |
| darwin amd64 | `/usr/local/bin/brew` |

- `--promptBool` の true/false 両分岐で展開し、生成物が TOML としてパースできること・行末空白が無いことを確認
- CI と同じく他の全 `*.tmpl` の `execute-template` も通ることを確認

## 挙動の差分

旧実装は「linux でも darwin でもない」場合に `[data.brew]` セクション自体を出力しなかったが、新実装は `else` で `/usr/local/bin/brew` にフォールバックする。issue の修正案どおりで、対象 OS は macOS / Ubuntu のみなので実害はない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)