### PR TITLE
Ubuntu ブートストラップの apt-get update と非対話インストールを修正

### DIFF
--- a/.chezmoiscripts/run_once_before_01_install_go.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_01_install_go.sh.tmpl
@@ -10,7 +10,12 @@ fi
 GO_URL="https://golang.org/dl/go${GO_VERSION}.{{.chezmoi.os}}-{{.chezmoi.arch}}.tar.gz"
 
 {{ if eq .chezmoi.os "linux" -}}
-sudo apt-get install -y curl
+if ! command -v curl >/dev/null 2>&1
+then
+  # 新規環境ではパッケージリストが空なので update してから install する
+  sudo apt-get update
+  sudo apt-get install -y curl
+fi
 {{ end }}
 
 curl -Lo /tmp/go.tar.gz $GO_URL || {

--- a/.chezmoiscripts/run_once_before_02_install_homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_02_install_homebrew.sh.tmpl
@@ -24,6 +24,8 @@ done
 
 if [ -n "$MISSING_PACKAGES" ]; then
     echo "Installing missing packages: $MISSING_PACKAGES"
+    # 新規環境ではパッケージリストが空なので update してから install する
+    sudo apt-get update
     # パッケージ名のリストなので意図的に単語分割させる
     # shellcheck disable=SC2086
     sudo apt-get install -y $MISSING_PACKAGES
@@ -32,7 +34,8 @@ fi
 
 
 echo "Starting Homebrew installation..."
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+# run_once スクリプトは非対話で流れるので Enter 待ちを抑止する
+NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 eval "$({{ .brew.path  }} shellenv)"
 


### PR DESCRIPTION
Closes #29

## 変更内容

### 1. `apt-get install` の前に `apt-get update` を実行

新規環境ではパッケージリストが空で `install` が失敗し得るため、両スクリプトの Linux 分岐に `sudo apt-get update` を追加した。

- `run_once_before_01_install_go.sh.tmpl` — あわせて `curl` の導入を未インストール時のみに限定し、毎回 `apt-get update` が走らないようにした
- `run_once_before_02_install_homebrew.sh.tmpl` — 不足パッケージがある場合のみ `update` → `install`

### 2. Homebrew インストーラーを `NONINTERACTIVE=1` で実行

`run_once` スクリプトは非対話で流れるため、インストーラーの Enter 入力待ちで止まらないようにした。

### 3. dpkg の存在確認 — 修正不要

issue では `dpkg -l | grep -qw $pkg` が問題として挙げられているが、現状のコードはすでに `dpkg-query -W -f='${Status}' "$pkg" | grep -q "ok installed"` になっており、説明文への誤マッチは起きない。

修正案の `dpkg -s` は「削除済みだが設定ファイルが残っている (`deinstall ok config-files`)」状態でも成功扱いになるため、現状の `dpkg-query` + Status 判定のほうが厳密。そのまま残した。

## 検証

- `chezmoi execute-template` での展開 (darwin) — OK
- Linux 分岐を手で展開したものへの `shellcheck` — OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)