### PR TITLE
NPM_CONFIG_USERCONFIG をファイルパスに修正

### DIFF
--- a/dot_config/zsh/dot_zshenv.tmpl
+++ b/dot_config/zsh/dot_zshenv.tmpl
@@ -18,7 +18,7 @@ export GOPATH="$XDG_DATA_HOME/go"
 export GOBIN="$GOPATH/bin"
 
 ### JS ###
-export NPM_CONFIG_USERCONFIG="$XDG_CONFIG_HOME/npm"
+export NPM_CONFIG_USERCONFIG="$XDG_CONFIG_HOME/npm/npmrc"
 
 ### Deno ###
 export DENO_INSTALL="$XDG_DATA_HOME/deno"


### PR DESCRIPTION
## 概要

`NPM_CONFIG_USERCONFIG` がディレクトリ (`$XDG_CONFIG_HOME/npm`) を指していたため、`npm config set` などが正しく動作しなかった。XDG 準拠の慣例パスである `$XDG_CONFIG_HOME/npm/npmrc` に修正した。

Closes #24

## テスト

- `chezmoi execute-template < dot_config/zsh/dot_zshenv.tmpl` で展開結果を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)