### PR TITLE
procs を packages.yaml に追加し wget エイリアスにガードを付ける

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -15,6 +15,7 @@ brew:
       - jq
       - eza
       - ripgrep
+      - procs
     mac:
       - borders
     cask:

--- a/dot_config/zsh/hooks/async.zsh.tmpl
+++ b/dot_config/zsh/hooks/async.zsh.tmpl
@@ -1,7 +1,10 @@
 alias rm='rm -i'
 alias ll='ls -lh'
 alias la='ls -a'
-alias wget="wget --hsts-file=$XDG_DATA_HOME/wget-hsts"
+
+if command -v wget >/dev/null 2>&1; then
+  alias wget="wget --hsts-file=$XDG_DATA_HOME/wget-hsts"
+fi
 
 if command -v nvim >/dev/null 2>&1; then
   alias vim='nvim'


### PR DESCRIPTION
Closes #30

## 変更内容

- `.chezmoidata/packages.yaml` の `brew.packages.common` に `procs` を追加
  - `async.zsh.tmpl` の `alias ps='procs'` は `command -v procs` ガード付きだが、`procs` が packages.yaml になくどの環境でも有効にならなかったため
- `dot_config/zsh/hooks/async.zsh.tmpl` の `wget` エイリアスを `command -v wget` ガードで囲む
  - 他のエイリアス (nvim / bat / fd / rg / eza) と流儀を揃える

## 確認したこと

- `chezmoi --source "$PWD" execute-template` で `brew.packages.common` に `procs` が乗ること、`async.zsh.tmpl` が展開できることを確認
- 展開後の `async.zsh` の `alias wget=...` に shellcheck SC2139 が出るが、これは変更前からある指摘 (`$XDG_DATA_HOME` が定義時展開) で、CI の shellcheck 対象は `.chezmoiscripts/*.sh` のみ

なお `procs` は `run_once_` スクリプトの都合上、既存環境では `chezmoi apply` だけでは入らない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)