### PR TITLE
サードパーティ tap を brew trust してから bundle するようにする

### DIFF
--- a/.chezmoidata/packages.yaml
+++ b/.chezmoidata/packages.yaml
@@ -1,4 +1,9 @@
 brew:
+  # 公式以外の tap。Homebrew 6.0 以降は brew trust での信頼登録が必要なため、
+  # run_once_after_02_execute_brew_bundle.sh.tmpl で trust してから tap する
+  taps:
+    mac:
+      - felixkratz/formulae
   packages:
     common:
       - chezmoi

--- a/.chezmoiscripts/run_once_after_02_execute_brew_bundle.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_02_execute_brew_bundle.sh.tmpl
@@ -1,12 +1,25 @@
 #!/bin/sh
 
+set -e
+
 if ! command -v brew >/dev/null 2>&1; then
     echo "brew command not found 😱"
     exit 1
 fi
 
 {{ if eq .chezmoi.os "darwin" -}}
+# Homebrew 6.0 以降、公式以外の tap の formula はロード前に信頼登録が必要。
+# trust.json の場所が $XDG_CONFIG_HOME に依存する (未設定だと ~/.homebrew/) ため、
+# どこから実行しても ~/.config/homebrew/trust.json に寄るよう明示する。
+XDG_CONFIG_HOME="${XDG_CONFIG_HOME:-$HOME/.config}"
+export XDG_CONFIG_HOME
+{{ range .brew.taps.mac -}}
+brew trust --tap {{ . | quote }}
+{{ end }}
 brew bundle --verbose --file=/dev/stdin <<EOF
+{{ range .brew.taps.mac -}}
+tap {{ . | quote }}
+{{ end -}}
 {{ range .brew.packages.common -}}
 brew {{ . | quote }}
 {{ end -}}


### PR DESCRIPTION
## 背景

`chezmoi update` で以下のエラーが出て `borders` がインストールできなくなっていた。

```
Error: Refusing to load formula felixkratz/formulae/borders from untrusted tap felixkratz/formulae.
Run `brew trust --formula felixkratz/formulae/borders` or `brew trust felixkratz/formulae` to trust it.
```

Homebrew 6.0 から、公式以外の tap の formula は `brew trust` で信頼登録しないとロード自体が拒否される。

あわせて以下の問題もあった。

- Brewfile に `tap "felixkratz/formulae"` 宣言がなく、既にローカルで tap 済みだから動いていただけで新規マシンでは解決できない
- スクリプトに `set -e` がなく、`brew bundle` が失敗しても「completed successfully 🎉」と表示され `chezmoi apply` も成功扱いになっていた

## 変更

- `.chezmoidata/packages.yaml` に `brew.taps.mac` を追加
- `brew bundle` の前に `brew trust --tap` を実行し、Brewfile 冒頭に `tap` 行を出力
- `trust.json` の保存先が `$XDG_CONFIG_HOME` 未設定時に `~/.homebrew/` へ逃げるため、リポジトリの XDG 方針に合わせて `~/.config/homebrew/trust.json` に寄るよう明示
- `set -e` を追加

`brew trust` は登録済みなら "Already trusted" を返すだけで冪等。run_once スクリプトは内容が変わったので次回の `chezmoi apply` でそのまま再実行される。

## 確認

- `chezmoi execute-template` での展開確認
- 展開後スクリプトの shellcheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)