### PR TITLE
.chezmoiscripts に set -eu を追加する

### DIFF
--- a/.chezmoiscripts/run_once_after_02_execute_brew_bundle.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_02_execute_brew_bundle.sh.tmpl
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -eu
 
 if ! command -v brew >/dev/null 2>&1; then
     echo "brew command not found 😱"

--- a/.chezmoiscripts/run_once_before_01_install_go.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_01_install_go.sh.tmpl
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -eu
+
 GO_VERSION=1.23.1
 
 if command -v go >/dev/null 2>&1

--- a/.chezmoiscripts/run_once_before_02_install_homebrew.sh.tmpl
+++ b/.chezmoiscripts/run_once_before_02_install_homebrew.sh.tmpl
@@ -1,4 +1,6 @@
 #!/bin/sh
+set -eu
+
 echo "brew path: {{ .brew.path }}"
 
 if command -v brew >/dev/null 2>&1


### PR DESCRIPTION
## 概要

`.chezmoiscripts/` の 3 つのスクリプトに `set -eu` がなく、途中のコマンドが失敗しても最後まで進んで exit 0 になっていた。`run_once_` はそのまま「実行済み」として chezmoi の state に記録されるため、失敗が永久に隠れてしまう。

Closes #23

## 変更内容

以下の冒頭に `set -eu` を追加:

- `.chezmoiscripts/run_once_after_02_execute_brew_bundle.sh.tmpl`
- `.chezmoiscripts/run_once_before_01_install_go.sh.tmpl`
- `.chezmoiscripts/run_once_before_02_install_homebrew.sh.tmpl`

## 副作用の確認

- `if command -v ...` / `if ! dpkg-query ... | grep -q` は条件式なので `set -e` の対象外
- `curl ... || { echo; exit 1; }` のエラーハンドリングは `||` の左辺なので影響なし (`set -e` と重複するが、メッセージを出すため残置)
- `eval "$(brew shellenv)"` の出力は `${PATH+:$PATH}` / `${INFOPATH:-}` という未定義安全な形式なので `set -u` でも問題なし
- `dpkg-query -W -f='${Status}'` はシングルクォート内なのでシェル展開されない

## 動作確認

CI と同じ手順 (全 `.chezmoiscripts/*.sh.tmpl` を `chezmoi execute-template` で展開 → `shellcheck`) をローカル (darwin/arm64) で実行しパス。Linux 分岐は CI の Ubuntu ランナーで検証される。

🤖 Generated with [Claude Code](https://claude.com/claude-code)