### PR TITLE
Apple Silicon の初回ブートストラップで brew bundle が失敗する問題を修正

### DIFF
--- a/.chezmoiscripts/run_once_after_02_execute_brew_bundle.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_02_execute_brew_bundle.sh.tmpl
@@ -1,7 +1,12 @@
 #!/bin/sh
 set -eu
 
-set -e
+# before スクリプトの eval shellenv は別プロセスなので、この after スクリプトに PATH が
+# 引き継がれない。Apple Silicon の /opt/homebrew/bin はデフォルト PATH に無いため、
+# 初回ブートストラップでは brew を見つけられない。ここでも shellenv を評価しておく。
+if ! command -v brew >/dev/null 2>&1 && [ -x "{{ .brew.path }}" ]; then
+    eval "$({{ .brew.path }} shellenv)"
+fi
 
 if ! command -v brew >/dev/null 2>&1; then
     echo "brew command not found 😱"


### PR DESCRIPTION
## 概要

Apple Silicon の新品マシンで `chezmoi init --apply` すると、Homebrew のインストール直後にもかかわらず `brew command not found 😱` で brew bundle がスキップされる問題を修正する。

before スクリプト内の `eval "$(... shellenv)"` は別プロセスなので after スクリプトに PATH が引き継がれず、`/opt/homebrew/bin` がデフォルト PATH に含まれない Apple Silicon では brew を解決できなかった (Intel は `/usr/local/bin` がデフォルト PATH にあるため偶然動いていた)。

## 変更内容

`.chezmoiscripts/run_once_after_02_execute_brew_bundle.sh.tmpl` の冒頭で shellenv を評価する。

- PATH に brew が無く、かつ `.brew.path` に実体がある場合のみ eval する (既に PATH が通っている環境では無駄な eval をしない)
- brew 自体が未インストールなら従来どおり `brew command not found 😱` で終わる。無条件 eval だと `set -e` で分かりにくいエラーになるため `-x` で守っている
- あわせて `set -eu` の直後に残っていた重複 `set -e` を削除

## 動作確認

- `chezmoi execute-template` で展開結果を確認 (Apple Silicon で `/opt/homebrew/bin/brew` に解決される)
- 展開後スクリプトの `shellcheck` が通ることを確認

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)