### PR TITLE
ログインシェルの zsh 化を自動化する

### DIFF
--- a/.chezmoiscripts/run_once_after_05_set_login_shell.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_05_set_login_shell.sh.tmpl
@@ -1,0 +1,51 @@
+#!/bin/sh
+set -eu
+
+# ログインシェルを zsh にする。
+# chezmoi apply は非対話で流れるため、chsh のパスワード入力を避けて sudo 経由で叩く。
+# ここで失敗しても apply 全体は止めず、手動手順を案内するだけにする。
+
+{{ if eq .chezmoi.os "linux" -}}
+if ! command -v zsh >/dev/null 2>&1; then
+  echo "Installing zsh..."
+  # 新規環境ではパッケージリストが空なので update してから install する
+  sudo apt-get update
+  sudo apt-get install -y zsh
+fi
+{{ end -}}
+
+zsh_path="$(command -v zsh || true)"
+if [ -z "$zsh_path" ]; then
+  echo "zsh が見つからないのでログインシェルの変更をスキップする 🙅" >&2
+  exit 0
+fi
+
+user="$(id -un)"
+
+{{ if eq .chezmoi.os "darwin" -}}
+# macOS には getent がないので dscl から引く
+current_shell="$(dscl . -read "/Users/$user" UserShell 2>/dev/null | awk '{ print $2 }')"
+{{- else -}}
+current_shell="$(getent passwd "$user" | cut -d: -f7)"
+{{- end }}
+
+# /bin/zsh と brew の zsh を行き来させたくないので、zsh でありさえすれば何もしない
+case "$current_shell" in
+  */zsh)
+    echo "Login shell is already zsh ($current_shell). 🙆‍♂️"
+    exit 0
+    ;;
+esac
+
+# chsh は /etc/shells に載っているシェルしか受け付けない
+if ! grep -qxF "$zsh_path" /etc/shells 2>/dev/null; then
+  echo "Adding $zsh_path to /etc/shells"
+  echo "$zsh_path" | sudo tee -a /etc/shells >/dev/null
+fi
+
+echo "Changing login shell: ${current_shell:-unknown} -> $zsh_path"
+if sudo chsh -s "$zsh_path" "$user"; then
+  echo "Login shell changed to zsh. 次のログインから反映される 🎉"
+else
+  echo "ログインシェルの変更に失敗した 😱 手動で 'chsh -s $zsh_path' を実行すること" >&2
+fi

--- a/.chezmoiscripts/run_once_after_05_set_login_shell.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_05_set_login_shell.sh.tmpl
@@ -4,13 +4,23 @@ set -eu
 # ログインシェルを zsh にする。
 # chezmoi apply は非対話で流れるため、chsh のパスワード入力を避けて sudo 経由で叩く。
 # ここで失敗しても apply 全体は止めず、手動手順を案内するだけにする。
+# set -eu 下では sudo の失敗がそのまま apply の中断になるので、
+# sudo を使う箇所はすべて give_up で受けること。
+give_up() {
+  echo "$1 😱" >&2
+  # ユーザーにそのままコピーさせるコマンド文字列なので展開させない
+  # shellcheck disable=SC2016
+  echo 'ログインシェルは手動で変更すること: chsh -s "$(command -v zsh)"' >&2
+  exit 0
+}
 
 {{ if eq .chezmoi.os "linux" -}}
 if ! command -v zsh >/dev/null 2>&1; then
   echo "Installing zsh..."
   # 新規環境ではパッケージリストが空なので update してから install する
-  sudo apt-get update
-  sudo apt-get install -y zsh
+  if ! { sudo apt-get update && sudo apt-get install -y zsh; }; then
+    give_up "zsh のインストールに失敗した (sudo が使えない?)"
+  fi
 fi
 {{ end -}}
 
@@ -40,12 +50,14 @@ esac
 # chsh は /etc/shells に載っているシェルしか受け付けない
 if ! grep -qxF "$zsh_path" /etc/shells 2>/dev/null; then
   echo "Adding $zsh_path to /etc/shells"
-  echo "$zsh_path" | sudo tee -a /etc/shells >/dev/null
+  # パイプの終了ステータスは tee のもの。sudo がこけた場合も tee は走らないのでここで拾える
+  if ! echo "$zsh_path" | sudo tee -a /etc/shells >/dev/null; then
+    give_up "/etc/shells への追記に失敗した (sudo が使えない?)"
+  fi
 fi
 
 echo "Changing login shell: ${current_shell:-unknown} -> $zsh_path"
-if sudo chsh -s "$zsh_path" "$user"; then
-  echo "Login shell changed to zsh. 次のログインから反映される 🎉"
-else
-  echo "ログインシェルの変更に失敗した 😱 手動で 'chsh -s $zsh_path' を実行すること" >&2
+if ! sudo chsh -s "$zsh_path" "$user"; then
+  give_up "ログインシェルの変更に失敗した (sudo が使えない?)"
 fi
+echo "Login shell changed to zsh. 次のログインから反映される 🎉"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@
 
 ## Requirements
 
-- zsh: ログインシェルに設定しておくこと
+- zsh: `chezmoi apply` 時に自動でインストール (Ubuntu のみ) / ログインシェルへ設定する。
+  `sudo` が使えない環境では変更をスキップして案内だけ出すので、その場合は
+  `chsh -s "$(command -v zsh)"` を手動で実行する。反映は次回ログインから。
 
 ## Installation
 


### PR DESCRIPTION
README の Requirements にあった「zsh: ログインシェルに設定しておくこと」という手動手順を `chezmoi apply` の中に取り込む。

## 変更内容

`.chezmoiscripts/run_once_after_05_set_login_shell.sh.tmpl` を追加。

1. Ubuntu のみ、zsh が未インストールなら `apt-get install -y zsh` (macOS は `/bin/zsh` が標準であるため不要)
2. 現在のログインシェルを取得する。macOS は `dscl . -read /Users/$user UserShell`、Linux は `getent passwd` (macOS に `getent` がないので OS 分岐)
3. すでに zsh なら何もしない。`/bin/zsh` と brew の zsh を行き来させたくないので、パス完全一致ではなく `*/zsh` で判定する
4. `chsh` は `/etc/shells` に載っているシェルしか受け付けないため、未登録なら `sudo tee -a` で追記
5. `sudo chsh -s`。`run_once` スクリプトは非対話で流れるので、パスワードプロンプトを避けて sudo 経由で叩く。失敗しても apply 全体は止めず、手動コマンドを案内するだけにする

あわせて README の Requirements を、自動化された旨と sudo が使えない場合の手動手順に書き換えた。

## 実行順とスクリプト番号について

`before` ではなく `after` にしている。`before` だと `~/.zshenv` や `~/.config/zsh/*` が未配置のままログインシェルが zsh になり、apply が途中でこけた場合や作業中に新しいターミナルを開いた場合に、ZDOTDIR も PATH も無い素の zsh に落ちる。テンプレート側で zsh に依存している箇所 (`lookPath`) も無いので、前倒しする理由がない。

番号は 05。dotfiles 配置 → brew → mise → 最後にログインシェル切り替え、という並びになる。

## 動作確認

このリポジトリの CI (macOS arm64 / macOS Intel / Ubuntu) がテンプレート展開と展開後の shellcheck を回す。手元では chezmoi が入れられなかったため、OS 分岐を手で展開した darwin / linux 両方の出力に shellcheck をかけて clean を確認した。

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzhUA79bh9iw87SpXKsPEX)_