### PR TITLE
mise install を config.toml の変更で再実行させる

### DIFF
--- a/.chezmoiscripts/run_onchange_after_04_install_mise_tools.sh.tmpl
+++ b/.chezmoiscripts/run_onchange_after_04_install_mise_tools.sh.tmpl
@@ -5,6 +5,15 @@ set -eu
 # mise activate が仕込む auto-install は対話シェルでコマンドを叩いたときしか効かず、
 # Neovim から起動する LSP や Makefile 経由の実行は PATH に無いまま落ちるため、
 # apply の中でランタイムを実体化させておく。
+#
+# run_once ではなく run_onchange なのは、スクリプトの再実行判定が「展開後の本文の
+# ハッシュ」で行われるため。run_once だと config.toml のバージョンだけ上げても
+# 本文が変わらず再実行されず、新しい config が置かれたのにランタイムが入らない
+# 状態になる。config.toml のハッシュを本文に埋めて、変更を再実行の契機にする。
+# run_once のままハッシュだけ埋める手もあるが、run_once は「過去に実行した本文」を
+# すべて覚えているため、バージョンを前の値に戻したときに再実行されない。
+# run_onchange は直前の本文としか比較しないので revert でも走る。
+# mise config: {{ include "dot_config/mise/config.toml" | sha256sum }}
 
 # 初回 apply では ~/.zshenv がまだ読まれておらず brew の PATH が通っていない
 if [ -x {{ .brew.path | squote }} ]
@@ -21,7 +30,7 @@ fi
 {{ if eq .chezmoi.os "linux" -}}
 # ruby は mise (ruby-build) がソースからビルドするのでヘッダ類が要る。
 # Homebrew 導入時の REQUIRED_PACKAGES には含まれていない分をここで補う。
-REQUIRED_PACKAGES="libyaml-dev libssl-dev zlib1g-dev"
+REQUIRED_PACKAGES="libyaml-dev libssl-dev zlib1g-dev libffi-dev libreadline-dev libgmp-dev"
 MISSING_PACKAGES=""
 
 for pkg in $REQUIRED_PACKAGES; do

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,7 +65,9 @@ XDG 準拠のため `ZDOTDIR` を `~/.config/zsh` に寄せている。読み込
 
 ## 言語ランタイム (mise)
 
-Go / Node / Ruby / uv などのランタイムは mise に一本化しており、バージョンは `dot_config/mise/config.toml` が唯一の情報源。mise 本体は brew bundle で入り、`.chezmoiscripts/run_once_after_04_install_mise_tools.sh.tmpl` が `chezmoi apply` の中で `mise install` まで済ませる。
+Go / Node / Ruby / uv などのランタイムは mise に一本化しており、バージョンは `dot_config/mise/config.toml` が唯一の情報源。mise 本体は brew bundle で入り、`.chezmoiscripts/run_onchange_after_04_install_mise_tools.sh.tmpl` が `chezmoi apply` の中で `mise install` まで済ませる。
+
+このスクリプトが `run_once_` ではなく `run_onchange_` なのは、再実行判定が**展開後のスクリプト本文のハッシュ**で行われるため。`run_once_` だと `dot_config/mise/config.toml` のバージョンを上げても本文が変わらず再実行されず、新しい config が配置されたのにランタイムが入らない状態になる。本文に `include "dot_config/mise/config.toml" | sha256sum` のテンプレート呼び出しをコメントとして埋めて、config の変更を再実行の契機にしている。`run_once_` のままハッシュだけ埋めても変更時には走るが、`run_once_` は過去に実行した本文をすべて記憶しているため**バージョンを前の値に戻したときに再実行されない**。`run_onchange_` は直前の本文としか比較しないので revert でも走る。ランタイム以外にも「ソースの別ファイルの変更で再実行したいスクリプト」を書く場合は同じ手を使う。
 
 **`mise use -g` は使わないこと。** 書き込み先が `~/.config/mise/config.toml` そのものなので、その場では切り替わっても次の `chezmoi apply` でソース側の内容に静かに巻き戻る (`chezmoi update` を回していると特に気づきにくい)。バージョンを変えるときはソースの `dot_config/mise/config.toml` を編集して apply する。
 


### PR DESCRIPTION
#55 のレビューで挙がった、mise スクリプト側の 2 点を対応する。#55 とは独立した変更なので別 PR にした。

## 1. `run_once_` → `run_onchange_` (再実行されない問題)

`run_once_` の再実行判定は**展開後のスクリプト本文のハッシュ**で行われる。本文に `dot_config/mise/config.toml` の内容は含まれないため、config でバージョンを上げて `chezmoi apply` しても新しい config は配置されるがスクリプトは走らず、ランタイムが入らないままになる。CLAUDE.md が「auto-install に頼れないので apply 時の `mise install` を省略しない」と書いている状況が、まさにこれで発生する。

本文に `include "dot_config/mise/config.toml" | sha256sum` のコメントを埋め、`run_onchange_` にした。

`run_once_` のままハッシュだけ埋める案もあるが、`run_once_` は過去に実行した本文をすべて記憶しているため、バージョンを前の値に戻したときに再実行されない。

## 2. ruby-build の依存パッケージを追加

Ubuntu で ruby をソースビルドする際に必要な `libffi-dev` / `libreadline-dev` / `libgmp-dev` が抜けていた。ビルドに失敗すると `set -eu` で apply 全体が止まる。

## 動作確認

チェック対象のスクリプトを最小化したプローブで、実際に `chezmoi apply` を回して挙動を確認した (chezmoi v2.65.0)。

| | 初回 apply | config 変更後 | 以前の値に revert |
| --- | --- | --- | --- |
| `run_once_` + ハッシュ無し (変更前) | 実行 | **実行されない** | – |
| `run_onchange_` + ハッシュ (本 PR) | 実行 | 実行 | **実行** |
| `run_once_` + ハッシュ | 実行 | 実行 | **実行されない** |

変更前の構成で問題が再現すること、本 PR の構成で解消することを確認している。あわせて全テンプレートの `chezmoi execute-template` と展開後スクリプトの shellcheck をローカルで通した (CI と同じ手順)。

ruby のソースビルド自体はこの環境では実行していない。パッケージ追加は ruby-build の推奨依存に基づく。

---
_Generated by [Claude Code](https://claude.ai/code/session_01SzhUA79bh9iw87SpXKsPEX)_