### PR TITLE
README を書き直す

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,23 +1,89 @@
 # dotfiles
 
-[chezmoi](https://www.chezmoi.io/)で管理。
+[chezmoi](https://www.chezmoi.io/) で管理している個人用 dotfiles。
 
-対象OS: MacOS(intel), Ubuntu
+対象 OS: macOS (Intel / Apple Silicon), Ubuntu
 
-## Requirements
-
-- zsh: `chezmoi apply` 時に自動でインストール (Ubuntu のみ) / ログインシェルへ設定する。
-  `sudo` が使えない環境では変更をスキップして案内だけ出すので、その場合は
-  `chsh -s "$(command -v zsh)"` を手動で実行する。反映は次回ログインから。
+`chezmoi apply` 一発で、Homebrew の導入からパッケージ・言語ランタイムのインストール、
+ログインシェルの設定までが済むようにしてある。OS / アーキテクチャの差分は Go テンプレートで吸収する。
 
 ## Installation
 
-### 1password cli の設定を行う(MacOS の場合)
+### 1. 1Password の設定 (macOS のみ)
 
-[公式](https://developer.1password.com/docs/cli/get-started/)を参考にして、1password cli と desktop アプリをインストールし、設定を行う。
+SSH 認証と git のコミット署名を 1Password に寄せているため、先に設定しておく。
+[公式ドキュメント](https://developer.1password.com/docs/cli/get-started/)を参考に、
+1Password デスクトップアプリと CLI をインストールし、SSH agent を有効にする。
 
-### 環境構築
+Linux では SSH agent もコミット署名プログラムも設定されない (署名自体は有効なので、
+必要なら machine-local な設定で上書きする)。
+
+### 2. 環境構築
 
 ```sh
 sh -c "$(curl -fsLS get.chezmoi.io)" -- init --apply kazu-2020
 ```
+
+初回の `chezmoi init` で「external な cask を入れるか」を聞かれる。
+回答は `~/.config/chezmoi/chezmoi.toml` に記録されるので、次回以降は聞かれない
+(聞き直したい場合は `chezmoi.toml` の `installExternal` を消してから `chezmoi init` する)。
+
+## apply で何が起きるか
+
+`.chezmoiscripts/` のスクリプトが番号順に走る。
+
+| スクリプト | 内容 |
+| --- | --- |
+| `before_02_install_homebrew` | Homebrew を入れる (Ubuntu では前提の apt パッケージも入れる) |
+| `after_01_create_XDG_directories` | `~/.config` などの XDG ディレクトリを作る |
+| `after_02_execute_brew_bundle` | `.chezmoidata/packages.yaml` の内容で `brew bundle` |
+| `after_03_migrate_irb_history` | irb の履歴ファイルを新しいパスへ移す (旧環境からの移行用) |
+| `after_04_install_mise_tools` | `~/.config/mise/config.toml` のランタイムを `mise install` |
+| `after_05_set_login_shell` | ログインシェルを zsh にする (Ubuntu では zsh のインストールも) |
+
+ログインシェルの変更は `sudo` を使う。`sudo` が使えない環境では apply を止めずに案内だけ出すので、
+その場合は手動で実行する。反映は次回ログインから。
+
+```sh
+chsh -s "$(command -v zsh)"
+```
+
+## 構成
+
+| パス | 内容 |
+| --- | --- |
+| `.chezmoidata/packages.yaml` | brew で入れるパッケージ一覧。**パッケージの追加はここ** |
+| `.chezmoi.toml.tmpl` | prompt の結果や OS 判定に依存する設定 (brew のパスなど) |
+| `.chezmoiscripts/` | apply 時に走るスクリプト |
+| `dot_config/zsh/` | zsh 設定。`ZDOTDIR` を `~/.config/zsh` に寄せ、sheldon で非同期ロード |
+| `dot_config/mise/config.toml` | 言語ランタイム (Go / Node / Ruby / uv) のバージョン。唯一の情報源 |
+| `dot_config/git/`, `nvim/`, `starship.toml`, ... | 各ツールの設定 |
+
+ファイル名のプレフィックスが配置先とパーミッションを決める chezmoi の規約に従う
+(`dot_foo` → `~/.foo`、`executable_` → 実行ビット、`*.tmpl` → テンプレート展開)。
+
+## メンテナンス
+
+```sh
+chezmoi apply                # ソースの内容をホームへ反映
+chezmoi update               # git pull してから apply
+chezmoi edit ~/.config/...   # ソース側のファイルを開く
+chezmoi execute-template < dot_config/zsh/sync.zsh.tmpl   # テンプレート展開結果の確認
+chezmoi data                 # テンプレートで参照できる変数の一覧
+```
+
+`run_once_` のスクリプトは内容を変えない限り再実行されない。強制的に走らせたい場合:
+
+```sh
+chezmoi state delete-bucket --bucket=scriptState
+```
+
+言語ランタイムのバージョンを変えるときは `mise use -g` ではなく
+`dot_config/mise/config.toml` を編集して `chezmoi apply` する
+(`mise use -g` の書き込み先は chezmoi 管理下のファイルなので、次の apply で巻き戻る)。
+
+## CI
+
+`.github/workflows/ci.yml` が macOS (arm64 / amd64) と Ubuntu の実ランナー上で、
+全テンプレートの `chezmoi execute-template` 検証・展開後スクリプトの shellcheck・
+`.chezmoidata` の構文チェックを行う。


### PR DESCRIPTION
## 概要

README の内容が薄く実態とずれていたので全面的に書き直した。

## 変更点

- **対象 OS を修正** — `MacOS(intel), Ubuntu` → `macOS (Intel / Apple Silicon), Ubuntu`。`.chezmoi.toml.tmpl` に arm64 分岐があり Apple Silicon には対応済みだった (Closes #31)
- **1Password の項に目的を明記** — SSH 認証とコミット署名のために要ること、Linux では設定されないこと
- **`chezmoi init` の prompt を説明** — 初回に external cask の可否を聞かれること、回答が記録されて再質問されないこと
- **「apply で何が起きるか」を追加** — `.chezmoiscripts/` 6 本を実行順の表に。Requirements にあった zsh の記述はここへ統合し、`sudo` が使えない場合の手動手順もこの流れに置いた
- **「構成」を追加** — パッケージ追加は `.chezmoidata/packages.yaml`、ランタイムのバージョンは `dot_config/mise/config.toml`、という「どこを触るか」が引ける表
- **「メンテナンス」を追加** — `chezmoi apply` / `update` / `execute-template`、`run_once_` の再実行方法、`mise use -g` を使わない理由
- **CI が何を検証しているかを追加**

CLAUDE.md と重複する内容もあるが、README は「新しいマシンで動かす人 / 後から自分で触る人」向け、CLAUDE.md は設計判断の理由を書く場、という切り分けで README 側は理由より手順に寄せている。

🤖 Generated with [Claude Code](https://claude.com/claude-code)