### PR TITLE
mise activate を command -v ガードで囲む

### DIFF
--- a/dot_config/zsh/hooks/async.zsh.tmpl
+++ b/dot_config/zsh/hooks/async.zsh.tmpl
@@ -38,7 +38,9 @@ fi
 
 
 ### mise ###
-eval "$(mise activate zsh)"
+if command -v mise >/dev/null 2>&1; then
+  eval "$(mise activate zsh)"
+fi
 
 {{ if eq .chezmoi.os "linux" -}}
 # ubuntu でパスフレーズの入力画面を出力するためのおまじない


### PR DESCRIPTION
## 概要

`dot_config/zsh/hooks/async.zsh.tmpl` の `mise activate` だけ `command -v` ガードが無く、mise が入っていない環境 (ブートストラップ失敗時など) ではシェル起動のたびに `command not found: mise` が出続けていた。同ファイル内の bat / fd / eza / procs などと同じ形でガードした。

```zsh
### mise ###
if command -v mise >/dev/null 2>&1; then
  eval "$(mise activate zsh)"
fi
```

## 確認

- `chezmoi execute-template` で展開結果を確認 (このブロックは OS 分岐の外なので macOS / Linux で同一)

Closes #64

🤖 Generated with [Claude Code](https://claude.com/claude-code)