### PR TITLE
zsh の履歴を $XDG_STATE_HOME/zsh/history に寄せる

### DIFF
--- a/.chezmoiscripts/run_once_after_07_migrate_zsh_history.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_07_migrate_zsh_history.sh.tmpl
@@ -1,0 +1,30 @@
+#!/bin/sh
+set -eu
+
+# zsh の履歴ファイルを $XDG_STATE_HOME/zsh_history から
+# $XDG_STATE_HOME/zsh/history へ移す (zcompdump と同じツール別ディレクトリに揃えた)。
+# 初回インストール時はまだ ~/.zshenv が読まれていないため XDG 変数が未定義。
+# 環境変数に頼らず、chezmoi が知っている適用先からパスを組み立てる。
+dest={{ .chezmoi.destDir | squote }}
+
+state="${XDG_STATE_HOME:-$dest/.local/state}"
+old="$state/zsh_history"
+new="$state/zsh/history"
+
+# 旧ファイルがなければ何もしない (新規環境ではこれが常態)
+[ -f "$old" ] || exit 0
+
+# 移行先が既にあるなら上書きせず旧ファイルを残す (履歴を失わないため)
+if [ -e "$new" ]; then
+  echo "skip: $new が既にあるため $old は移動しない" >&2
+  exit 0
+fi
+
+mkdir -p "$(dirname "$new")"
+mv "$old" "$new"
+chmod 600 "$new"
+echo "moved: $old -> $new"
+
+# 起動中の zsh は旧パスの HISTFILE を掴んだままなので、以降に打ったコマンドは
+# $old へ書き戻される (このスクリプトは run_once_ なので拾い直されない)。
+echo "note: 起動中の zsh は $old へ書き続ける。新しいシェルを開き直すこと" >&2

--- a/.chezmoiscripts/run_once_after_07_migrate_zsh_history.sh.tmpl
+++ b/.chezmoiscripts/run_once_after_07_migrate_zsh_history.sh.tmpl
@@ -20,11 +20,12 @@ if [ -e "$new" ]; then
   exit 0
 fi
 
-mkdir -p "$(dirname "$new")"
+# irb の移行と違いディレクトリは chmod しない。ここは zcompdump と共用で、
+# 新規環境では sync.zsh の mkdir が作る (履歴の保護は下の chmod 600 が担う)。
+mkdir -p "$state/zsh"
 mv "$old" "$new"
 chmod 600 "$new"
 echo "moved: $old -> $new"
 
-# 起動中の zsh は旧パスの HISTFILE を掴んだままなので、以降に打ったコマンドは
-# $old へ書き戻される (このスクリプトは run_once_ なので拾い直されない)。
+# 起動中の zsh は旧パスの HISTFILE を掴んだままで、以降のコマンドは $old へ書き戻される
 echo "note: 起動中の zsh は $old へ書き続ける。新しいシェルを開き直すこと" >&2

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,10 @@ XDG 準拠のため `ZDOTDIR` を `~/.config/zsh` に寄せている。読み込
 - `hooks/async.zsh.tmpl` — エイリアスと mise 有効化。sheldon の `[plugins.async]` から遅延 source される
 - `hooks/zeno-pre.zsh` / `zeno-post.zsh` — zeno の環境変数とキーバインド。プラグインの `hooks.pre` / `hooks.post` から呼ばれる
 
+zsh の状態ファイル (`HISTFILE` と `zcompdump`) は `$XDG_STATE_HOME/zsh/` にまとめる。**このディレクトリを作るのは `sync.zsh.tmpl` だけ**なので、`.zshrc` での `sync.zsh` → `sheldon source` の順序を崩さないこと。崩すと compinit が dump を黙って作らず毎回フルスキャンに戻る (エラーは出ない)。
+
+配置先を変えるときは `run_once_after_0N_migrate_*.sh.tmpl` を 1 本足して既存環境のファイルを移す (irb / zsh 履歴の前例がある)。移行スクリプトは apply 時にまだ `~/.zshenv` が読まれていない前提で、`XDG_*` ではなく `.chezmoi.destDir` からパスを組み立てる。
+
 **TAB (`^i`) の補完 UI は fzf-tab に寄せる方針**。zeno は `config.yml` の `snippets:` を使うスニペット展開と履歴選択・ghq cd に限定して使い、`zeno-completion` は bind しない。両方を bind すると `zsh-defer` の FIFO 実行で後から読まれた方が勝つため、読み込み順に依存した壊れ方をする。
 
 `sheldon/plugins.toml` の `[templates] defer` 内の `{{ }}` は sheldon (Tera) のテンプレート構文であり、chezmoi のものではない。このファイルは `.tmpl` ではないので chezmoi は展開しないが、`.tmpl` 化する場合は `{{` のエスケープが必要になる。

--- a/dot_config/zsh/dot_zshrc
+++ b/dot_config/zsh/dot_zshrc
@@ -1,3 +1,5 @@
+# sync.zsh は sheldon より先に読むこと。$XDG_STATE_HOME/zsh を作るのがここだけなので、
+# 順序を入れ替えると compinit が dump を黙って作らなくなる (毎回フルスキャンに戻る)。
 source $ZDOTDIR/sync.zsh
 
 eval "$(sheldon source)"

--- a/dot_config/zsh/sheldon/plugins.toml
+++ b/dot_config/zsh/sheldon/plugins.toml
@@ -18,9 +18,8 @@ post = "zsh-defer source $ZDOTDIR/hooks/zeno-post.zsh"
 [plugins.compinit]
 inline = """
 # ディレクトリが無いと compinit は dump を黙って作らず、毎回フルスキャンになる。
-# 2 回目以降の起動で fork しないよう組み込みの [[ -d ]] でガードする。
+# $XDG_STATE_HOME/zsh は HISTFILE と共用で、sheldon より前に読まれる sync.zsh が作る。
 : "${XDG_STATE_HOME:=$HOME/.local/state}"
-[[ -d $XDG_STATE_HOME/zsh ]] || mkdir -p $XDG_STATE_HOME/zsh
 
 # 補完の設定は compinit より前に済ませておく。
 # fzf-tab はグループ名に compadd の説明文字列 ($expl) を使うので、

--- a/dot_config/zsh/sync.zsh.tmpl
+++ b/dot_config/zsh/sync.zsh.tmpl
@@ -37,7 +37,12 @@ eval "$({{ .brew.path  }} shellenv)"
 export PURE_GIT_PULL=0
 
 ### history ###
-export HISTFILE="$XDG_STATE_HOME/zsh_history"
+# zcompdump と同じ $XDG_STATE_HOME/zsh/ に置く。ディレクトリが無いと zsh は履歴を
+# 保存できないので、ここで作る (sheldon より前に読まれる唯一の場所)。
+# 2 回目以降の起動で fork しないよう組み込みの [[ -d ]] でガードする。
+[[ -d $XDG_STATE_HOME/zsh ]] || mkdir -p $XDG_STATE_HOME/zsh
+
+export HISTFILE="$XDG_STATE_HOME/zsh/history"
 # HISTSIZE < SAVEHIST だと古い履歴がメモリに載らず Ctrl-R で引けないので揃える
 export HISTSIZE=100000
 export SAVEHIST=100000


### PR DESCRIPTION
Closes #70

## 変更内容

`HISTFILE` を `$XDG_STATE_HOME/zsh_history` から `$XDG_STATE_HOME/zsh/history` に移し、zcompdump と置き場を揃えた。

- `dot_config/zsh/sync.zsh.tmpl` — `HISTFILE` を新パスに変更。ディレクトリが無いと zsh は履歴を保存できないので、`[[ -d ]]` ガード付きの `mkdir` をここに置いた (`.zshrc` で sheldon より前に読まれる唯一の場所)
- `dot_config/zsh/sheldon/plugins.toml` — 同じ `mkdir` が compinit 側にもあったので削除し、sync.zsh が作る旨をコメントに残した
- `.chezmoiscripts/run_once_after_07_migrate_zsh_history.sh.tmpl` — 既存環境向けの移行スクリプト。`run_once_after_03_migrate_irb_history` と同じ構成
- `dot_config/zsh/dot_zshrc` / `CLAUDE.md` — 読み込み順への依存と状態ファイルの置き場の規約を明記

## 補足

irb の移行スクリプトとの差分は 2 点。

- ディレクトリの `chmod 700` はしていない。ここは zcompdump と共用で、新規環境では sync.zsh の `mkdir` が作るため、移行機だけ 700 になると環境間で食い違う。履歴の保護は `chmod 600` が担う
- apply 時に起動中の zsh は旧パスの `HISTFILE` を掴んだままで `fc -AI` がそこへ書き続ける (`run_once_` なので拾い直されない) ため、シェルを開き直すよう stderr に注意を出している

`mkdir` を sync.zsh に一本化したことで「sync.zsh が sheldon より先」が前提になった。この失敗モードはエラーではなく「compinit が dump を黙って作らず毎回フルスキャン」という無音の性能劣化なので、`.zshrc` と CLAUDE.md の両方に制約を書いた。

## 検証

- 移行スクリプト: `chezmoi execute-template` 展開 → shellcheck 通過。旧ファイルあり / 新規環境 / 移行先が既存の 3 ケースを一時ディレクトリで実行し、期待どおりの動作 (移行後の `history` は 600) を確認
- `sync.zsh`: 展開後に `zsh -n` 通過。実際に source して `HISTFILE` が新パスを指し、ディレクトリが作られることを確認
- `chezmoi managed --include=scripts` に `.chezmoiscripts/07_migrate_zsh_history.sh` が載ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)