### PR TITLE
zsh-completions の無意味な defer を外し compinit より前に置く

### DIFF
--- a/dot_config/zsh/sheldon/plugins.toml
+++ b/dot_config/zsh/sheldon/plugins.toml
@@ -15,6 +15,15 @@ apply = ["defer"]
 pre = "zsh-defer source $ZDOTDIR/hooks/zeno-pre.zsh"
 post = "zsh-defer source $ZDOTDIR/hooks/zeno-post.zsh"
 
+# src/ には補完関数 (_foo) しか無く source 対象のファイルが無いので、defer しても
+# 何も出力されない。fpath への追加だけが仕事なので apply も fpath だけにしてある。
+#
+# fpath は compinit より前に積む必要があるため、compinit より上に置く。
+[plugins.zsh-completions]
+github = "zsh-users/zsh-completions"
+dir = "src"
+apply = ["fpath"]
+
 [plugins.compinit]
 inline = """
 # ディレクトリが無いと compinit は dump を黙って作らず、毎回フルスキャンになる。
@@ -48,11 +57,6 @@ apply = ["defer"]
 [plugins.zsh-autosuggestions]
 github = "zsh-users/zsh-autosuggestions"
 apply = ["defer"]
-
-[plugins.zsh-completions]
-github = "zsh-users/zsh-completions"
-dir = "src"
-apply = ["defer", "fpath"]
 
 [plugins.async]
 inline = """


### PR DESCRIPTION
Closes #69

## 変更内容

- `[plugins.zsh-completions]` の `apply` を `["defer", "fpath"]` → `["fpath"]` に変更
- `[plugins.zsh-completions]` を `[plugins.compinit]` の直前へ移動し、ファイル上の順序と実行順序 (fpath → compinit) を一致させた
- なぜ defer が不要なのか / なぜ compinit より上なのかをコメントで明記

## 背景

zsh-completions の `src/` には `_foo` 形式の補完関数しか無く source 対象のファイルが存在しないため、`defer` テンプレートは 1 行も出力していなかった (実質デッドコンフィグ)。

また fpath 追加が compinit より先に効いていたのは「compinit が `zsh-defer` で遅延されている」ことに依存した順序で、ファイル上は `[plugins.compinit]` の方が先に書かれていて読み手に誤解を与える状態だった。

## 検証

`sheldon source` の出力を変更前後で比較。生成される行は完全に同一で、`fpath=( .../zsh-completions/src $fpath )` が compinit の直前に移動しただけであることを確認した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)