### PR TITLE
nvim に検索・インデント・undo の基本オプションを足す

### DIFF
--- a/dot_config/nvim/lua/config.lua
+++ b/dot_config/nvim/lua/config.lua
@@ -7,6 +7,9 @@ vim.g.mapleader = " "
 vim.opt.title = true
 vim.opt.number = true
 vim.opt.cursorline = true
+-- サインの出入りで本文が左右にずれないよう常時表示する
+vim.opt.signcolumn = "yes"
+vim.opt.scrolloff = 5
 vim.opt.mouse = "a"
 vim.opt.clipboard = "unnamedplus"
 vim.opt.autoindent = true
@@ -14,6 +17,18 @@ vim.opt.smartindent = true
 
 vim.opt.expandtab = true
 vim.opt.shiftwidth = 2
+-- 行中で Tab / BS を押したときの幅。負値は shiftwidth に追従する指定。
+-- tabstop は「既にあるタブ文字の表示幅」で担当が別なので触らない
+-- (2 にすると Go や Makefile のインデントまで浅く描画される)
+vim.opt.softtabstop = -1
+
+vim.opt.ignorecase = true
+vim.opt.smartcase = true
+vim.opt.splitright = true
+vim.opt.splitbelow = true
+
+-- undodir のデフォルトが $XDG_STATE_HOME/nvim/undo なのでパスは指定しない
+vim.opt.undofile = true
 
 vim.opt.list = true
 vim.opt.listchars = { tab = '>>', trail = '-', nbsp = '+' }


### PR DESCRIPTION
Closes #75

`dot_config/nvim/lua/config.lua` に検索・インデント・undo・分割方向の基本オプションを追加する。プラグインの追加は無し。

## issue から変えた点が 2 つある

### 1. `tabstop = 2` は入れず、`softtabstop = -1` にした

issue では `tabstop` と `softtabstop` を両方 2 にする案だったが、「行中で Tab を押すと 8 幅入る」問題に効いていたのは `softtabstop` の方だった。`expandtab` が有効なのでタブ文字は挿入されず、`tabstop` は「既にあるタブ文字の表示幅」しか変えない。

実測 (nvim 0.12.4、`expandtab` + `shiftwidth=2`、`ab` の後で Tab):

| 設定 | 結果 |
| --- | --- |
| `sts=0, ts=8` (変更前) | `ab______cd` |
| `sts=2, ts=8` | `ab__cd` |
| `sts=-1, ts=8` | `ab__cd` |

そのうえで `tabstop = 2` はタブを使う言語に漏れる。`runtime/ftplugin/go.vim:33` は Go バッファで `noexpandtab softtabstop=0 shiftwidth=0` に戻すが **`tabstop` は戻さない**。`shiftwidth=0` は `tabstop` にフォールバックする指定なので、グローバルで `tabstop=2` にすると Go の 1 インデントが 2 桁で描画される。

| グローバル設定 | Go バッファの実効インデント幅 |
| --- | --- |
| `tabstop=2` | 2 桁 |
| `tabstop` に触らない | 8 桁 |

エラーは出ず、gofmt 済みのファイルが浅く見えるだけなので気づきにくい。`.chezmoidata` 経由で mise に Go が入っている以上、実際に踏む。

`softtabstop` の負値は「`shiftwidth` を使う」の意味 (`:h 'softtabstop'`) なので、インデント幅 `2` の実体は `shiftwidth` の 1 行だけになる。

### 2. `updatetime = 250` は見送った

`CursorHold` を使うプラグインがこのリポジトリにまだ 1 つも無い (プラグインは tokyonight / hop / vim-sandwich / vimdoc-ja の 4 本、`nvim_get_autocmds({event="CursorHold"})` も 0 件)。一方で swap ファイルの書き出しは実測で 12 秒あたり 1 回 → 10 回に増える。

このリポジトリは `hop.lua` が自分のキーマップを持つように、プラグイン固有の事情を `lua/plugins/*.lua` 側に置く構造なので、LSP や gitsigns を入れる PR でその spec の隣に置く方が値の由来も追える。

## `undofile` について

`undodir` のデフォルトが `~/.local/state/nvim/undo//` で、`dot_zshenv.tmpl` の `XDG_STATE_HOME` と一致している。ディレクトリの自動生成も upstream が保証しているため (`runtime/doc/vim_diff.txt:94` に "auto-created")、`undodir` の明示も `run_once_after_01_create_XDG_directories.sh.tmpl` への追加も不要。あのスクリプトは XDG ルート 4 つだけを作る設計なので、アプリ個別のサブディレクトリは持ち込まない。

## 検証

`nvim --headless` で `config.lua` を読み込ませ、実効値と挙動を確認した。

- 通常バッファ: `softtabstop=-1` / `tabstop=8` / 行中 Tab は `ab__cd`
- Go バッファ: 実効インデント幅 8 桁
- `undodir` = `/Users/matazou/.local/state/nvim/undo//`
- 追加した全オプションが nvim 0.12.4 のデフォルトと異なることを確認済み (無意味な行なし)

## 補足 (この PR では対応しない)

- リポジトリに `.editorconfig` が無い。nvim 0.12 は EditorConfig を標準サポートするので、置けば「リポジトリの契約」と「個人の既定値」を分離できる。ただし chezmoi のソースルートに置くと `~/.editorconfig` として配置されるので `.chezmoiignore` とセットになる
- 既存行の `vim.opt.autoindent = true` と `listchars` の `trail` / `nbsp` は nvim のデフォルトと同値

🤖 Generated with [Claude Code](https://claude.com/claude-code)
