### PR TITLE
シェル起動時の brew / sheldon の fork を削る

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,6 +77,8 @@ zsh の状態ファイル (`HISTFILE` と `zcompdump`) は `$XDG_STATE_HOME/zsh/
 
 - **焼き込みに chezmoi の `output` 関数は使えない。** `brew shellenv` は PATH の先頭が既に brew の `bin`/`sbin` だと何も出力しない (`Library/Homebrew/cmd/shellenv.sh` の冒頭)。brew を通したシェルから apply すると空文字列が焼き込まれ、エラーも出ないまま PATH が壊れる。brew 側の出力が変わったときは `env -i PATH=/usr/bin:/bin "$(command -v brew)" shellenv zsh` (PATH を汚さない状態で叩く) と突き合わせて追随する。
 - **キャッシュを無名関数などに包まないこと。** `pure` のように defer せず直接 source されるプラグインの `typeset` が関数ローカルになり、グローバルに置いたつもりの変数が消える。
+- **`sheldon source` の終了ステータスは信用できない。** 取得に失敗したプラグインを黙って落とした出力を吐いて exit 0 する (ERROR は stderr に出るだけ)。欠けた出力をそのまま焼くと mtime だけ新しくなり、次に `plugins.toml` を編集するまで直らない。`sheldon lock` は同じ状況で非 0 を返すのでゲートに使う。
+- **キャッシュは書けてから `mv` で差し替えること。** source されている当のファイルを直接 truncate すると、同時に起動した別のシェルが途中まで書かれたスクリプトを読む。書き損ねたキャッシュが mtime だけ新しくなるのも防げる。
 
 ## 言語ランタイム (mise)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ chezmoi data              # テンプレートで参照できる変数の一覧
    - `onepassword.yaml` — 1Password の SSH agent ソケットのパス。zshenv とチェックスクリプトの 2 箇所から参照されるので、値をここに寄せている
 2. `.chezmoi.toml.tmpl` が生成する `~/.config/chezmoi/chezmoi.toml` — prompt や OS 判定に依存して `.chezmoidata` に置けないもの:
    - `[data.brew.packages.cask] external` / `installExternal` — `chezmoi init` 時の `promptBoolOnce` で入れるか選ばせる。回答は `installExternal` として書き出され、次回以降の `chezmoi init` はそれを引き継ぐので再質問されない (質問し直したい場合は `chezmoi.toml` からこのキーを消す)
-   - `[data.brew] path` — OS/アーキテクチャごとの brew パス (`/opt/homebrew`, `/usr/local`, `/home/linuxbrew/.linuxbrew`)。`sync.zsh.tmpl` の `eval "$({{ .brew.path }} shellenv)"` などがこれを参照する
+   - `[data.brew] path` — OS/アーキテクチャごとの brew パス (`/opt/homebrew`, `/usr/local`, `/home/linuxbrew/.linuxbrew`)。`sync.zsh.tmpl` が `brew shellenv` 相当を焼き込むときの prefix (`dir` を 2 回) などがこれを参照する
 
 `.chezmoidata/` は chezmoi が毎回自動で読むので、1 を編集した場合は `chezmoi apply` するだけで反映される。
 
@@ -54,12 +54,22 @@ XDG 準拠のため `ZDOTDIR` を `~/.config/zsh` に寄せている。読み込
        └─ ~/.config/zsh/.zshrc    sync.zsh を source → sheldon で残りを非同期ロード
 ```
 
-- `sync.zsh.tmpl` — 起動時に同期実行が必要なもの (PATH 構築、brew shellenv、history、setopt)
+- `sync.zsh.tmpl` — 起動時に同期実行が必要なもの (PATH 構築、brew の環境変数、history、setopt)
 - `sheldon/plugins.toml` — プラグイン管理。`zsh-defer` を使った `defer` テンプレートで大半を遅延ロードする
 - `hooks/async.zsh.tmpl` — エイリアスと mise 有効化。sheldon の `[plugins.async]` から遅延 source される
 - `hooks/zeno-pre.zsh` / `zeno-post.zsh` — zeno の環境変数とキーバインド。プラグインの `hooks.pre` / `hooks.post` から呼ばれる
 
 zsh の状態ファイル (`HISTFILE` と `zcompdump`) は `$XDG_STATE_HOME/zsh/` にまとめる。**このディレクトリを作るのは `sync.zsh.tmpl` だけ**なので、`.zshrc` での `sync.zsh` → `sheldon source` の順序を崩さないこと。崩すと compinit が dump を黙って作らず毎回フルスキャンに戻る (エラーは出ない)。
+
+### 起動時の fork を増やさない
+
+対話シェルの起動は毎回走るので、`sync.zsh` と `.zshrc` では**外部コマンドを呼ばない**方針。起動時の fork は 2 つとも潰してある (#68)。
+
+- **brew** — `eval "$(brew shellenv)"` はやめ、展開結果を `sync.zsh.tmpl` に焼き込んでいる。macOS 14+ の `shellenv` は PATH 構築を `path_helper` に投げるので、eval すると brew (bash) + env + path_helper で 1 起動 3 プロセス増える。
+  - **焼き込みに chezmoi の `output` 関数は使えない。** `shellenv` は PATH の先頭が既に brew の `bin`/`sbin` だと何も出力しない (`Library/Homebrew/cmd/shellenv.sh` の冒頭)。brew を通したシェルから apply すると空文字列が焼き込まれ、エラーも出ないまま PATH が壊れる。
+  - brew 側の出力が変わったときは `env -i PATH=/usr/bin:/bin "$(command -v brew)" shellenv zsh` (PATH を汚さない状態で叩く) と突き合わせて追随する。
+- **sheldon** — `sheldon source` の出力を `$XDG_CACHE_HOME/sheldon/plugins.zsh` にキャッシュし、`plugins.toml` の方が新しいときだけ作り直す。生成に失敗したときは古いキャッシュを残す (壊れたキャッシュを source すると、プラグインが丸ごと消えた状態が次の `plugins.toml` 更新まで居座るため)。プラグインの実体を消したなど `plugins.toml` 以外の理由で作り直したいときはキャッシュファイルを消す。
+  - **このキャッシュを無名関数などに包まないこと。** `pure` のように defer せず直接 source されるプラグインの `typeset` が関数ローカルになり、グローバルに置いたつもりの変数が消える。
 
 配置先を変えるときは `run_once_after_0N_migrate_*.sh.tmpl` を 1 本足して既存環境のファイルを移す (irb / zsh 履歴の前例がある)。移行スクリプトは apply 時にまだ `~/.zshenv` が読まれていない前提で、`XDG_*` ではなく `.chezmoi.destDir` からパスを組み立てる。
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,7 +36,7 @@ chezmoi data              # テンプレートで参照できる変数の一覧
    - `onepassword.yaml` — 1Password の SSH agent ソケットのパス。zshenv とチェックスクリプトの 2 箇所から参照されるので、値をここに寄せている
 2. `.chezmoi.toml.tmpl` が生成する `~/.config/chezmoi/chezmoi.toml` — prompt や OS 判定に依存して `.chezmoidata` に置けないもの:
    - `[data.brew.packages.cask] external` / `installExternal` — `chezmoi init` 時の `promptBoolOnce` で入れるか選ばせる。回答は `installExternal` として書き出され、次回以降の `chezmoi init` はそれを引き継ぐので再質問されない (質問し直したい場合は `chezmoi.toml` からこのキーを消す)
-   - `[data.brew] path` — OS/アーキテクチャごとの brew パス (`/opt/homebrew`, `/usr/local`, `/home/linuxbrew/.linuxbrew`)。`sync.zsh.tmpl` が `brew shellenv` 相当を焼き込むときの prefix (`dir` を 2 回) などがこれを参照する
+   - `[data.brew] path` — OS/アーキテクチャごとの brew パス (`/opt/homebrew`, `/usr/local`, `/home/linuxbrew/.linuxbrew`)。`sync.zsh.tmpl` はここから prefix を導出して `brew shellenv` 相当を焼き込む
 
 `.chezmoidata/` は chezmoi が毎回自動で読むので、1 を編集した場合は `chezmoi apply` するだけで反映される。
 
@@ -61,16 +61,6 @@ XDG 準拠のため `ZDOTDIR` を `~/.config/zsh` に寄せている。読み込
 
 zsh の状態ファイル (`HISTFILE` と `zcompdump`) は `$XDG_STATE_HOME/zsh/` にまとめる。**このディレクトリを作るのは `sync.zsh.tmpl` だけ**なので、`.zshrc` での `sync.zsh` → `sheldon source` の順序を崩さないこと。崩すと compinit が dump を黙って作らず毎回フルスキャンに戻る (エラーは出ない)。
 
-### 起動時の fork を増やさない
-
-対話シェルの起動は毎回走るので、`sync.zsh` と `.zshrc` では**外部コマンドを呼ばない**方針。起動時の fork は 2 つとも潰してある (#68)。
-
-- **brew** — `eval "$(brew shellenv)"` はやめ、展開結果を `sync.zsh.tmpl` に焼き込んでいる。macOS 14+ の `shellenv` は PATH 構築を `path_helper` に投げるので、eval すると brew (bash) + env + path_helper で 1 起動 3 プロセス増える。
-  - **焼き込みに chezmoi の `output` 関数は使えない。** `shellenv` は PATH の先頭が既に brew の `bin`/`sbin` だと何も出力しない (`Library/Homebrew/cmd/shellenv.sh` の冒頭)。brew を通したシェルから apply すると空文字列が焼き込まれ、エラーも出ないまま PATH が壊れる。
-  - brew 側の出力が変わったときは `env -i PATH=/usr/bin:/bin "$(command -v brew)" shellenv zsh` (PATH を汚さない状態で叩く) と突き合わせて追随する。
-- **sheldon** — `sheldon source` の出力を `$XDG_CACHE_HOME/sheldon/plugins.zsh` にキャッシュし、`plugins.toml` の方が新しいときだけ作り直す。生成に失敗したときは古いキャッシュを残す (壊れたキャッシュを source すると、プラグインが丸ごと消えた状態が次の `plugins.toml` 更新まで居座るため)。プラグインの実体を消したなど `plugins.toml` 以外の理由で作り直したいときはキャッシュファイルを消す。
-  - **このキャッシュを無名関数などに包まないこと。** `pure` のように defer せず直接 source されるプラグインの `typeset` が関数ローカルになり、グローバルに置いたつもりの変数が消える。
-
 配置先を変えるときは `run_once_after_0N_migrate_*.sh.tmpl` を 1 本足して既存環境のファイルを移す (irb / zsh 履歴の前例がある)。移行スクリプトは apply 時にまだ `~/.zshenv` が読まれていない前提で、`XDG_*` ではなく `.chezmoi.destDir` からパスを組み立てる。
 
 **TAB (`^i`) の補完 UI は fzf-tab に寄せる方針**。zeno は `config.yml` の `snippets:` を使うスニペット展開と履歴選択・ghq cd に限定して使い、`zeno-completion` は bind しない。両方を bind すると `zsh-defer` の FIFO 実行で後から読まれた方が勝つため、読み込み順に依存した壊れ方をする。
@@ -78,6 +68,15 @@ zsh の状態ファイル (`HISTFILE` と `zcompdump`) は `$XDG_STATE_HOME/zsh/
 `sheldon/plugins.toml` の `[templates] defer` 内の `{{ }}` は sheldon (Tera) のテンプレート構文であり、chezmoi のものではない。このファイルは `.tmpl` ではないので chezmoi は展開しないが、`.tmpl` 化する場合は `{{` のエスケープが必要になる。
 
 新しいシェル設定を追加する際は、遅延させてよいものは `hooks/async.zsh.tmpl` に、PATH や `setopt` など即時に必要なものは `sync.zsh.tmpl` に置く。
+
+### 起動時に外部コマンドを呼ばない
+
+`sync.zsh` と `.zshrc` は対話シェルの起動ごとに走るので、**ここに `eval "$(...)"` を足さない**。値が静的なら chezmoi の展開時に焼き込み、生成物ならキャッシュして source する (`brew shellenv` と `sheldon source` がそれぞれの前例)。制約は対話シェルの起動経路だけの話で、apply 時に一度動く `.chezmoiscripts/` が `eval "$(brew shellenv)"` を使うのは問題ない。
+
+焼き込みとキャッシュには、それぞれ黙って壊れる罠がある:
+
+- **焼き込みに chezmoi の `output` 関数は使えない。** `brew shellenv` は PATH の先頭が既に brew の `bin`/`sbin` だと何も出力しない (`Library/Homebrew/cmd/shellenv.sh` の冒頭)。brew を通したシェルから apply すると空文字列が焼き込まれ、エラーも出ないまま PATH が壊れる。brew 側の出力が変わったときは `env -i PATH=/usr/bin:/bin "$(command -v brew)" shellenv zsh` (PATH を汚さない状態で叩く) と突き合わせて追随する。
+- **キャッシュを無名関数などに包まないこと。** `pure` のように defer せず直接 source されるプラグインの `typeset` が関数ローカルになり、グローバルに置いたつもりの変数が消える。
 
 ## 言語ランタイム (mise)
 

--- a/dot_config/zsh/dot_zshrc
+++ b/dot_config/zsh/dot_zshrc
@@ -2,4 +2,29 @@
 # 順序を入れ替えると compinit が dump を黙って作らなくなる (毎回フルスキャンに戻る)。
 source $ZDOTDIR/sync.zsh
 
-eval "$(sheldon source)"
+# sheldon source の出力は plugins.toml に対して静的なので、起動のたびに sheldon を
+# fork せずキャッシュを source する。plugins.toml の方が新しければ作り直す
+# (chezmoi apply は内容が変わったときだけ書き出すので mtime で判定できる)。
+#
+# プラグインの実体を消した / lock を手で更新したなど toml 以外の理由で作り直したい
+# ときは、このキャッシュファイルを消せば次の起動で再生成される。
+#
+# キャッシュは無名関数などに包まないこと。中で source するプラグイン (pure など) の
+# typeset が関数ローカルになり、グローバルに置いたつもりの変数が消える。
+: "${XDG_CACHE_HOME:=$HOME/.cache}"
+__sheldon_cache="$XDG_CACHE_HOME/sheldon/plugins.zsh"
+
+if [[ ! -r $__sheldon_cache || $SHELDON_CONFIG_DIR/plugins.toml -nt $__sheldon_cache ]]; then
+    [[ -d $__sheldon_cache:h ]] || mkdir -p $__sheldon_cache:h
+    # 生成に失敗したキャッシュを source すると、プラグインが丸ごと消えた状態が
+    # 次の plugins.toml 更新まで居座る。書けたときだけ差し替える
+    if sheldon source >| $__sheldon_cache.new; then
+        mv -f $__sheldon_cache.new $__sheldon_cache
+    else
+        print -u2 "zshrc: sheldon source に失敗したためキャッシュを更新しない"
+        rm -f $__sheldon_cache.new
+    fi
+fi
+
+[[ -r $__sheldon_cache ]] && source $__sheldon_cache
+unset __sheldon_cache

--- a/dot_config/zsh/dot_zshrc
+++ b/dot_config/zsh/dot_zshrc
@@ -5,25 +5,22 @@ source $ZDOTDIR/sync.zsh
 # sheldon source の出力は plugins.toml に対して静的なので、起動のたびに sheldon を
 # fork せずキャッシュを source する。plugins.toml の方が新しければ作り直す
 # (chezmoi apply は内容が変わったときだけ書き出すので mtime で判定できる)。
-#
-# プラグインの実体を消した / lock を手で更新したなど toml 以外の理由で作り直したい
-# ときは、このキャッシュファイルを消せば次の起動で再生成される。
+# toml 以外の理由で作り直したいときはキャッシュファイルを消せばよい。
 #
 # キャッシュは無名関数などに包まないこと。中で source するプラグイン (pure など) の
 # typeset が関数ローカルになり、グローバルに置いたつもりの変数が消える。
-: "${XDG_CACHE_HOME:=$HOME/.cache}"
 __sheldon_cache="$XDG_CACHE_HOME/sheldon/plugins.zsh"
 
 if [[ ! -r $__sheldon_cache || $SHELDON_CONFIG_DIR/plugins.toml -nt $__sheldon_cache ]]; then
-    [[ -d $__sheldon_cache:h ]] || mkdir -p $__sheldon_cache:h
     # 生成に失敗したキャッシュを source すると、プラグインが丸ごと消えた状態が
-    # 次の plugins.toml 更新まで居座る。書けたときだけ差し替える
-    if sheldon source >| $__sheldon_cache.new; then
-        mv -f $__sheldon_cache.new $__sheldon_cache
+    # 次の plugins.toml 更新まで居座る。出力を受け取れたときだけ書き出す
+    if __sheldon_source=$(sheldon source); then
+        mkdir -p $__sheldon_cache:h
+        print -r -- $__sheldon_source >| $__sheldon_cache
     else
         print -u2 "zshrc: sheldon source に失敗したためキャッシュを更新しない"
-        rm -f $__sheldon_cache.new
     fi
+    unset __sheldon_source
 fi
 
 [[ -r $__sheldon_cache ]] && source $__sheldon_cache

--- a/dot_config/zsh/dot_zshrc
+++ b/dot_config/zsh/dot_zshrc
@@ -12,16 +12,30 @@ source $ZDOTDIR/sync.zsh
 __sheldon_cache="$XDG_CACHE_HOME/sheldon/plugins.zsh"
 
 if [[ ! -r $__sheldon_cache || $SHELDON_CONFIG_DIR/plugins.toml -nt $__sheldon_cache ]]; then
-    # 生成に失敗したキャッシュを source すると、プラグインが丸ごと消えた状態が
-    # 次の plugins.toml 更新まで居座る。出力を受け取れたときだけ書き出す
-    if __sheldon_source=$(sheldon source); then
+    # sheldon source は取得に失敗したプラグインを黙って落とした出力を吐いて exit 0
+    # する。それを焼くと mtime だけ新しくなり、欠けたまま次の plugins.toml 編集まで
+    # 直らない (オフラインで最初のシェルを開いた場合など)。lock は同じ状況で非 0 を
+    # 返すのでゲートに使う。再生成時しか走らないので起動コストには乗らない
+    if sheldon lock >/dev/null && __sheldon_source=$(sheldon source 2>/dev/null); then
+        # 他のシェルが source している最中に truncate しないよう、書けてから mv で
+        # 差し替える。書き損ねたキャッシュが mtime だけ新しくなるのも防げる
         mkdir -p $__sheldon_cache:h
-        print -r -- $__sheldon_source >| $__sheldon_cache
+        if print -r -- $__sheldon_source >| $__sheldon_cache.$$; then
+            mv -f $__sheldon_cache.$$ $__sheldon_cache
+        else
+            rm -f $__sheldon_cache.$$
+            print -u2 "zshrc: sheldon のキャッシュを書き出せなかった"
+        fi
     else
         print -u2 "zshrc: sheldon source に失敗したためキャッシュを更新しない"
     fi
-    unset __sheldon_source
 fi
 
-[[ -r $__sheldon_cache ]] && source $__sheldon_cache
-unset __sheldon_cache
+# 取れた出力があればそれが最新なので優先する。キャッシュを書けなかったときも
+# このシェルだけは素の eval で動く (二重ロードしないよう分岐は排他にする)
+if [[ -n $__sheldon_source ]]; then
+    eval $__sheldon_source
+elif [[ -r $__sheldon_cache ]]; then
+    source $__sheldon_cache
+fi
+unset __sheldon_cache __sheldon_source

--- a/dot_config/zsh/sync.zsh.tmpl
+++ b/dot_config/zsh/sync.zsh.tmpl
@@ -1,8 +1,10 @@
 ### locale ###
 export LANG="en_US.UTF-8"
 
-# 通常は ~/.zshenv が定義済み。未定義でも HISTFILE などが / 直下を指さないようにする
+# 通常は ~/.zshenv が定義済み。未定義でも HISTFILE などが / 直下を指さないようにする。
+# sync.zsh は .zshrc より先に読まれる唯一の場所なので、XDG の既定値はここに集める
 : "${XDG_STATE_HOME:=$HOME/.local/state}"
+: "${XDG_CACHE_HOME:=$HOME/.cache}"
 
 ### uniq path ###
 typeset -gU PATH path
@@ -25,14 +27,12 @@ path=(
     "$path[@]"
 )
 
-{{/* bin/brew が実体なのは /opt/homebrew (Apple Silicon) だけで、/usr/local (Intel) と
-       linuxbrew の bin/brew は $prefix/Homebrew/bin/brew への symlink。brew はこの差を
-       そのまま HOMEBREW_REPOSITORY に出す (bin/brew の symlink 解決を参照) */ -}}
+{{/* prefix は .brew.path (.chezmoi.toml.tmpl が OS/アーキテクチャごとに決める) から
+       導出する。値を持たせると path と食い違いうるので、単一の情報源から引く。
+       repository は brew が bin/brew の symlink を解決して決めるもので、実体を置く
+       /opt/homebrew だけ prefix と一致し、他 (Intel / linuxbrew) は $prefix/Homebrew */ -}}
 {{- $brewPrefix := .brew.path | dir | dir -}}
-{{- $brewRepository := $brewPrefix -}}
-{{- if ne $brewPrefix "/opt/homebrew" -}}
-{{-   $brewRepository = printf "%s/Homebrew" $brewPrefix -}}
-{{- end -}}
+{{- $brewRepository := ternary $brewPrefix (printf "%s/Homebrew" $brewPrefix) (eq $brewPrefix "/opt/homebrew") -}}
 ### brew ###
 # `brew shellenv` の出力を chezmoi の展開時に焼き込んだもの。起動のたびに brew
 # (bash スクリプト) を fork せずに済む。macOS 14+ の shellenv は PATH の構築を
@@ -40,10 +40,8 @@ path=(
 #
 # 焼き込みに chezmoi の output 関数は使えない。shellenv は PATH の先頭が既に
 # brew の bin/sbin だと何も出力しない仕様なので、brew を通したシェルから apply
-# すると空文字列が焼き込まれ、エラーも出ないまま PATH が壊れる。
-#
-# brew を入れ替えて出力が変わったら、`env -i PATH=/usr/bin:/bin {{ .brew.path }} shellenv zsh`
-# (PATH を汚さない状態で叩く) と突き合わせて追随する。
+# すると空文字列が焼き込まれ、エラーも出ないまま PATH が壊れる。追随のしかたは
+# CLAUDE.md の「起動時に外部コマンドを呼ばない」を参照。
 export HOMEBREW_PREFIX={{ $brewPrefix | quote }}
 export HOMEBREW_CELLAR={{ printf "%s/Cellar" $brewPrefix | quote }}
 export HOMEBREW_REPOSITORY={{ $brewRepository | quote }}
@@ -51,7 +49,6 @@ export INFOPATH="{{ $brewPrefix }}/share/info:${INFOPATH:-}"
 # MANPATH は未設定なら触らない (先頭のコロンが system の man パスを意味するため)
 [[ -z ${MANPATH-} ]] || export MANPATH=":${MANPATH#:}"
 
-# shellenv は fpath の先頭に挿し、FPATH を export する
 fpath=(
     {{ $brewPrefix }}/share/zsh/site-functions(N-/)
     "$fpath[@]"

--- a/dot_config/zsh/sync.zsh.tmpl
+++ b/dot_config/zsh/sync.zsh.tmpl
@@ -25,8 +25,46 @@ path=(
     "$path[@]"
 )
 
+{{/* bin/brew が実体なのは /opt/homebrew (Apple Silicon) だけで、/usr/local (Intel) と
+       linuxbrew の bin/brew は $prefix/Homebrew/bin/brew への symlink。brew はこの差を
+       そのまま HOMEBREW_REPOSITORY に出す (bin/brew の symlink 解決を参照) */ -}}
+{{- $brewPrefix := .brew.path | dir | dir -}}
+{{- $brewRepository := $brewPrefix -}}
+{{- if ne $brewPrefix "/opt/homebrew" -}}
+{{-   $brewRepository = printf "%s/Homebrew" $brewPrefix -}}
+{{- end -}}
 ### brew ###
-eval "$({{ .brew.path  }} shellenv)"
+# `brew shellenv` の出力を chezmoi の展開時に焼き込んだもの。起動のたびに brew
+# (bash スクリプト) を fork せずに済む。macOS 14+ の shellenv は PATH の構築を
+# path_helper に投げるので、素直に eval すると 1 起動あたり 3 プロセス増える。
+#
+# 焼き込みに chezmoi の output 関数は使えない。shellenv は PATH の先頭が既に
+# brew の bin/sbin だと何も出力しない仕様なので、brew を通したシェルから apply
+# すると空文字列が焼き込まれ、エラーも出ないまま PATH が壊れる。
+#
+# brew を入れ替えて出力が変わったら、`env -i PATH=/usr/bin:/bin {{ .brew.path }} shellenv zsh`
+# (PATH を汚さない状態で叩く) と突き合わせて追随する。
+export HOMEBREW_PREFIX={{ $brewPrefix | quote }}
+export HOMEBREW_CELLAR={{ printf "%s/Cellar" $brewPrefix | quote }}
+export HOMEBREW_REPOSITORY={{ $brewRepository | quote }}
+export INFOPATH="{{ $brewPrefix }}/share/info:${INFOPATH:-}"
+# MANPATH は未設定なら触らない (先頭のコロンが system の man パスを意味するため)
+[[ -z ${MANPATH-} ]] || export MANPATH=":${MANPATH#:}"
+
+# shellenv は fpath の先頭に挿し、FPATH を export する
+fpath=(
+    {{ $brewPrefix }}/share/zsh/site-functions(N-/)
+    "$fpath[@]"
+)
+export FPATH
+
+# macOS 14+ の shellenv は path_helper 経由だが、PATH_HELPER_ROOT が効くと読むのは
+# $prefix/etc/paths (既定で bin と sbin) だけなので、結果はこの 2 つの前置と等しい
+path=(
+    {{ $brewPrefix }}/bin(N-/)
+    {{ $brewPrefix }}/sbin(N-/)
+    "$path[@]"
+)
 
 ### prompt (pure) ###
 # pure はデフォルトでプロンプトのたびに裏で git fetch する。非同期なので描画は


### PR DESCRIPTION
Closes #68

## 計測

| | before | after |
|---|---|---|
| 対話 zsh の起動 | 37.7 ms | 17.5 ms |

内訳は `brew shellenv` ≈ 8.9ms、`sheldon source` ≈ 8.4ms。macOS 14+ の `shellenv` は PATH 構築を `path_helper` に投げるので、実際は 1 起動あたり 3 プロセス増えていた。

## brew — 展開時に焼き込む

issue の提案どおり chezmoi の `output` 関数を使うのは**危険なので採用していない**。`shellenv` は PATH の先頭が既に brew の `bin`/`sbin` だと何も出力しない仕様 (`Library/Homebrew/cmd/shellenv.sh` 冒頭の early return) で、brew を通したシェルから apply すると空文字列が焼き込まれ、エラーも出ないまま PATH が壊れる。

代わりに `.brew.path` から prefix を導出して `shellenv` 相当を直接書いた。apply 時に brew が存在する必要がなくなり、`path_helper` の fork も消える。

`HOMEBREW_REPOSITORY` だけは prefix と一致しない (Intel と linuxbrew は `$prefix/Homebrew`) ため分岐させ、3 レイアウト分の導出を検証した。

## sheldon — 出力をキャッシュ

`$XDG_CACHE_HOME/sheldon/plugins.zsh` に置き、`plugins.toml` の方が新しいときだけ作り直す。生成に失敗したときは古いキャッシュを残す (壊れたキャッシュを source すると、プラグインが丸ごと消えた状態が次の `plugins.toml` 更新まで居座るため)。

無名関数で包んでいないのは、`pure` のように defer されず直接 source されるプラグインの `typeset` が関数ローカルになるのを避けるため。

## 検証

- 旧 `eval "$(brew shellenv)"` と新実装をクリーン環境で走らせ、`PATH` / `FPATH` / `HOMEBREW_*` / `INFOPATH` / `MANPATH` / FPATH の export 有無まで **diff 完全一致**を確認
- キャッシュの生成・`plugins.toml` 更新での再生成・`sheldon` 失敗時のフォールバックを一時 ZDOTDIR で動作確認
- CI 相当の全テンプレート展開と、展開後の `zsh -n`

🤖 Generated with [Claude Code](https://claude.com/claude-code)