### PR TITLE
CI で chezmoi apply 自体を検証する

### DIFF
--- a/.github/scripts/verify-apply.sh
+++ b/.github/scripts/verify-apply.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+#
+# chezmoi apply 自体を検証する。
+#
+# テンプレート展開 (execute-template) だけでは属性プレフィックス (create_ /
+# executable_) の誤りや .chezmoiignore のパターンずれが捕まらないため、使い捨ての
+# 一時ディレクトリへ実際に配置して結果を検査する。CI から呼ぶが、引数なしで手元から
+# 実行しても同じ検査が回る (配置先は毎回 mktemp -d なので $HOME には触らない)。
+#
+# 使い方: .github/scripts/verify-apply.sh [ソースディレクトリ]
+set -euo pipefail
+
+src="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+dest="$(mktemp -d)"
+rc=0
+
+ng() {
+  echo "NG: $*" >&2
+  rc=1
+}
+
+# スクリプトは brew install などの副作用を伴うため配置対象から外す
+# (スクリプト本文の検証はワークフロー側の shellcheck が担当する)
+chezmoi apply --source "$src" --destination "$dest" --exclude scripts
+echo "OK: chezmoi apply --destination $dest"
+
+# 冪等性。apply 済みの配置先に対して status が何か報告するなら、展開結果が
+# 非決定的か、書けていないエントリがある
+st="$(chezmoi status --source "$src" --destination "$dest" --exclude scripts)"
+if [ -z "$st" ]; then
+  echo "OK: 2 回目の status が空"
+else
+  ng "apply 後も status が差分を報告する
+$st"
+fi
+
+# .chezmoiignore の検証。chezmoi ignored が挙げるのは「実在するエントリを実際に
+# 抑止したパターン」だけなので、ソース名で書いてしまって何にも一致しないパターンは
+# ここから消える。「ソース名を書いても静かに無視される」を直接突けるのはこの一覧だけ
+case "$(uname -s)" in
+  # 06 は darwin 限定なので、Linux ではスクリプトごと ignore される
+  Darwin) expected=(CLAUDE.md README.md) ;;
+  *) expected=(CLAUDE.md README.md .chezmoiscripts/06_check_1password_ssh_agent.sh) ;;
+esac
+want="$(printf '%s\n' "${expected[@]}" | LC_ALL=C sort)"
+got="$(chezmoi ignored --source "$src" --destination "$dest" | LC_ALL=C sort)"
+if [ "$got" = "$want" ]; then
+  echo "OK: chezmoi ignored ($(uname -s))"
+else
+  ng "ignored されるエントリが想定と違う
+--- 期待
+$want
+--- 実際
+$got"
+fi
+
+# 配置結果の走査。ここで 2 つ見る:
+#
+# 1. ファイル名が `xxx_` で始まっていないこと。属性プレフィックスの綴りを間違えると
+#    (creat_ / exectuable_ など) chezmoi はただの名前として扱い、そのまま配置先に
+#    残る。配置先に snake_case の名前が必要になったらこの判定を見直すこと
+# 2. shebang が sh 系のファイルを shellcheck にかけること。.tmpl でない生の
+#    シェルスクリプトは他のどのステップでも検査されない。あわせて、shebang が
+#    あるのに実行できない = ソース側で executable_ を付け忘れた、も拾う
+scripts=()
+while IFS= read -r -d '' f; do
+  if [[ "${f##*/}" =~ ^[a-z]+_ ]]; then
+    ng "属性プレフィックスの綴り間違いに見える: ${f#"$dest"/}"
+  fi
+  [ -f "$f" ] || continue
+
+  IFS= read -r shebang < "$f" || true
+  case "$shebang" in
+    # zsh は shellcheck が扱えないので外す。bash も dash も env 形式も末尾は sh
+    '#!'*zsh*) ;;
+    '#!'*sh | '#!'*sh\ *)
+      scripts+=("$f")
+      [ -x "$f" ] ||
+        ng "shebang 付きだが実行ビットが無い: ${f#"$dest"/} (executable_ の付け忘れ?)"
+      ;;
+  esac
+done < <(find "$dest" -mindepth 1 -print0)
+
+if [ "${#scripts[@]}" -eq 0 ]; then
+  ng "shebang 付きのシェルスクリプトが 1 つも見つからない (走査が壊れている?)"
+else
+  printf 'shellcheck: %s\n' "${scripts[@]}"
+  shellcheck "${scripts[@]}" || rc=1
+fi
+
+exit "$rc"

--- a/.github/scripts/verify-apply.sh
+++ b/.github/scripts/verify-apply.sh
@@ -5,28 +5,47 @@
 # テンプレート展開 (execute-template) だけでは属性プレフィックス (create_ /
 # executable_) の誤りや .chezmoiignore のパターンずれが捕まらないため、使い捨ての
 # 一時ディレクトリへ実際に配置して結果を検査する。CI から呼ぶが、引数なしで手元から
-# 実行しても同じ検査が回る (配置先は毎回 mktemp -d なので $HOME には触らない)。
+# 実行しても同じ検査が回る。
 #
 # 使い方: .github/scripts/verify-apply.sh [ソースディレクトリ]
 set -euo pipefail
 
 src="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
-dest="$(mktemp -d)"
 rc=0
+
+# 配置先・config・永続ステートをすべて使い捨ての一時ディレクトリに閉じ込める。
+# --destination だけでは永続ステート (~/.config/chezmoi/chezmoistate.boltdb) が
+# $HOME 側のままなので、--persistent-state まで渡して初めて切り離せる
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+dest="$work/dest"
+mkdir "$dest"
+
+cm() {
+  chezmoi --source "$src" --destination "$dest" \
+    --config "$work/chezmoi.toml" --persistent-state "$work/state.boltdb" "$@"
+}
 
 ng() {
   echo "NG: $*" >&2
   rc=1
 }
 
+# config も自前で作る。$HOME の chezmoi.toml に依存すると、init 済みの環境と未 init の
+# クローンで結果が変わり、CI と手元で見ているデータが食い違う (未 init だと .brew.path
+# が引けず、アサーション以前にテンプレートエラーで落ちる)。execute-template ではなく
+# init を使うのは、こちらは config テンプレートのハッシュを永続ステートにも記録するため。
+# 記録が無いと以降の apply / status が「config が古い」と毎回警告する
+cm init --promptBool "Do you want to install external casks=true"
+
 # スクリプトは brew install などの副作用を伴うため配置対象から外す
 # (スクリプト本文の検証はワークフロー側の shellcheck が担当する)
-chezmoi apply --source "$src" --destination "$dest" --exclude scripts
-echo "OK: chezmoi apply --destination $dest"
+cm apply --exclude scripts
+echo "OK: chezmoi apply"
 
 # 冪等性。apply 済みの配置先に対して status が何か報告するなら、展開結果が
 # 非決定的か、書けていないエントリがある
-st="$(chezmoi status --source "$src" --destination "$dest" --exclude scripts)"
+st="$(cm status --exclude scripts)"
 if [ -z "$st" ]; then
   echo "OK: 2 回目の status が空"
 else
@@ -43,7 +62,7 @@ case "$(uname -s)" in
   *) expected=(CLAUDE.md README.md .chezmoiscripts/06_check_1password_ssh_agent.sh) ;;
 esac
 want="$(printf '%s\n' "${expected[@]}" | LC_ALL=C sort)"
-got="$(chezmoi ignored --source "$src" --destination "$dest" | LC_ALL=C sort)"
+got="$(cm ignored | LC_ALL=C sort)"
 if [ "$got" = "$want" ]; then
   echo "OK: chezmoi ignored ($(uname -s))"
 else
@@ -54,14 +73,32 @@ $want
 $got"
 fi
 
-# 配置結果の走査。ここで 2 つ見る:
+# shebang からインタプリタ名を取り出す。`#!/usr/bin/env -S bash -e` のような
+# env 形式やオプション付きも吸収する
+interpreter() {
+  local words word
+  read -r -a words <<< "${1#\#!}" || true
+  [ "${#words[@]}" -eq 0 ] && return
+  for word in "${words[@]}"; do
+    case "$word" in
+      -* | *=*) continue ;; # env のオプションと VAR=value を読み飛ばす
+    esac
+    word="${word##*/}"
+    [ "$word" = env ] || {
+      printf '%s\n' "$word"
+      return
+    }
+  done
+}
+
+# 配置結果の走査。ここで 3 つ見る:
 #
 # 1. ファイル名が `xxx_` で始まっていないこと。属性プレフィックスの綴りを間違えると
 #    (creat_ / exectuable_ など) chezmoi はただの名前として扱い、そのまま配置先に
 #    残る。配置先に snake_case の名前が必要になったらこの判定を見直すこと
-# 2. shebang が sh 系のファイルを shellcheck にかけること。.tmpl でない生の
-#    シェルスクリプトは他のどのステップでも検査されない。あわせて、shebang が
-#    あるのに実行できない = ソース側で executable_ を付け忘れた、も拾う
+# 2. shebang があるのに実行できない = ソース側で executable_ を付け忘れている
+# 3. shellcheck が扱えるインタプリタのものを shellcheck にかけること。.tmpl でない
+#    生のシェルスクリプトは他のどのステップでも検査されない
 scripts=()
 while IFS= read -r -d '' f; do
   if [[ "${f##*/}" =~ ^[a-z]+_ ]]; then
@@ -70,19 +107,20 @@ while IFS= read -r -d '' f; do
   [ -f "$f" ] || continue
 
   IFS= read -r shebang < "$f" || true
-  case "$shebang" in
-    # zsh は shellcheck が扱えないので外す。bash も dash も env 形式も末尾は sh
-    '#!'*zsh*) ;;
-    '#!'*sh | '#!'*sh\ *)
-      scripts+=("$f")
-      [ -x "$f" ] ||
-        ng "shebang 付きだが実行ビットが無い: ${f#"$dest"/} (executable_ の付け忘れ?)"
-      ;;
+  case "$shebang" in '#!'*) ;; *) continue ;; esac
+  [ -x "$f" ] ||
+    ng "shebang 付きだが実行ビットが無い: ${f#"$dest"/} (executable_ の付け忘れ?)"
+
+  # 対象は sh / bash / dash / ksh / busybox sh のみ (shellcheck が読めるのがこれだけで、
+  # 他は SC1071 になる)。zsh や fish のスクリプトを足したときに落ちないよう、shebang の
+  # 末尾が sh かどうかではなくインタプリタ名で判定する (末尾一致では fish や csh も拾う)
+  case "$(interpreter "$shebang")" in
+    sh | bash | dash | ksh | busybox) scripts+=("$f") ;;
   esac
 done < <(find "$dest" -mindepth 1 -print0)
 
 if [ "${#scripts[@]}" -eq 0 ]; then
-  ng "shebang 付きのシェルスクリプトが 1 つも見つからない (走査が壊れている?)"
+  ng "shellcheck 対象のシェルスクリプトが 1 つも見つからない (走査が壊れている?)"
 else
   printf 'shellcheck: %s\n' "${scripts[@]}"
   shellcheck "${scripts[@]}" || rc=1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,117 +84,14 @@ jobs:
           done
           shellcheck "$tmpdir"/*.sh
 
-      # 属性プレフィックス (create_ / executable_ など) の誤りや .chezmoiignore の
-      # パターンずれはテンプレート展開では捕まらないので、実際に apply して確かめる。
-      # スクリプトは brew install などの副作用を伴うため --exclude scripts で外す
-      # (スクリプト本文の検証は上の shellcheck が担当する)。
-      # 配置先は使い捨ての一時ディレクトリで、ランナーの $HOME には触らない
+      # 属性プレフィックスの誤りや .chezmoiignore のパターンずれはテンプレート展開では
+      # 捕まらないので、使い捨ての一時ディレクトリへ実際に apply して確かめる。中身を
+      # ワークフローに埋めず引数なしでも動くスクリプトにしてあるので、手元で同じものを
+      # 実行して落ちたステップを再現できる (ついでにここで自身も shellcheck にかける)
       - name: Verify chezmoi apply
         run: |
-          dest="$(mktemp -d)"
-          echo "APPLY_DEST=$dest" >> "$GITHUB_ENV"
-          chezmoi apply --source "$GITHUB_WORKSPACE" --destination "$dest" --exclude scripts
-          # 冪等性の確認。apply 済みの配置先に対して status が何か報告するなら、
-          # 展開結果が非決定的か、書けていないエントリがある
-          st="$(chezmoi status --source "$GITHUB_WORKSPACE" --destination "$dest" --exclude scripts)"
-          if [ -n "$st" ]; then
-            printf 'NG: apply 後も status が差分を報告する\n%s\n' "$st" >&2
-            exit 1
-          fi
-          echo "OK: chezmoi apply --destination $dest"
-
-      - name: Verify applied attributes and .chezmoiignore
-        run: |
-          rc=0
-
-          # executable_ が実行ビットになっているか。ソース名から配置先への変換は
-          # chezmoi 自身に解決させ、プレフィックスの規則を CI 側に複製しない
-          while IFS= read -r src; do
-            tgt="$(chezmoi target-path --source "$GITHUB_WORKSPACE" \
-                     --destination "$APPLY_DEST" "$src")"
-            if [ -x "$tgt" ]; then
-              echo "OK: executable $src"
-            else
-              echo "NG: 実行ビットが立っていない $src -> $tgt" >&2
-              rc=1
-            fi
-          done < <(find . -path ./.git -prune -o -type f -name '*executable_*' -print | sort)
-
-          # 属性プレフィックスの綴りを間違えると (creat_ / exectuable_ など) chezmoi は
-          # ただの名前として扱い、そのまま配置先のファイル名に残る。配置後の名前が
-          # `xxx_` で始まっていたらこれを疑う (正当な配置先に該当する名前は無い)
-          while IFS= read -r -d '' f; do
-            if [[ "$(basename "$f")" =~ ^[a-z]+_ ]]; then
-              echo "NG: 属性プレフィックスの綴り間違いに見える: ${f#"$APPLY_DEST"/}" >&2
-              rc=1
-            fi
-          done < <(find "$APPLY_DEST" -mindepth 1 -print0)
-
-          # .chezmoiignore に書いたリポジトリ用のファイルが配置されていないこと
-          for f in README.md CLAUDE.md; do
-            if [ -e "$APPLY_DEST/$f" ]; then
-              echo "NG: .chezmoiignore で除外したはずの $f が配置された" >&2
-              rc=1
-            else
-              echo "OK: ignored $f"
-            fi
-          done
-
-          # 06 は darwin 限定。.chezmoiignore のパターンはソース名ではなく展開後の
-          # ターゲット名で書く必要があり、間違えても静かに無視されるので managed で見る
-          # (grep -q にパイプで渡すと pipefail 下で上流が SIGPIPE で落ちうるので、
-          # いったん変数に受けてから照合する)
-          target=".chezmoiscripts/06_check_1password_ssh_agent.sh"
-          scripts="$(chezmoi managed --source "$GITHUB_WORKSPACE" \
-                       --destination "$APPLY_DEST" --include=scripts)"
-          if grep -qxF "$target" <<< "$scripts"; then
-            managed=yes
-          else
-            managed=no
-          fi
-          if [ "$RUNNER_OS" = macOS ]; then
-            want=yes
-          else
-            want=no
-          fi
-          if [ "$managed" = "$want" ]; then
-            echo "OK: $target managed=$managed ($RUNNER_OS)"
-          else
-            echo "NG: $target が $RUNNER_OS で managed=$managed (期待は $want)" >&2
-            rc=1
-          fi
-
-          exit "$rc"
-
-      # テンプレートでない生のシェルスクリプト (dot_config/borders/executable_bordersrc
-      # など) は rendered .chezmoiscripts の shellcheck では拾えない。配置結果を走査して
-      # shebang が sh / bash のものを対象にする (zsh は shellcheck が扱えないので除く)
-      - name: Shellcheck applied shell scripts
-        run: |
-          files=()
-          while IFS= read -r -d '' f; do
-            case "$(head -n 1 "$f")" in
-              '#!'*/sh | '#!'*/sh\ * | '#!'*/bash | '#!'*/bash\ * | \
-                '#!'*env\ sh* | '#!'*env\ bash*)
-                files+=("$f")
-                ;;
-            esac
-          done < <(find "$APPLY_DEST" -type f -print0)
-          if [ "${#files[@]}" -eq 0 ]; then
-            echo "NG: shebang 付きのシェルスクリプトが 1 つも見つからない (走査が壊れている?)" >&2
-            exit 1
-          fi
-          # shebang があるのに実行できない = ソース側で executable_ の付け忘れ
-          rc=0
-          for f in "${files[@]}"; do
-            [ -x "$f" ] || {
-              echo "NG: shebang 付きだが実行ビットが無い: ${f#"$APPLY_DEST"/} (executable_ の付け忘れ?)" >&2
-              rc=1
-            }
-          done
-          printf 'checking: %s\n' "${files[@]}"
-          shellcheck "${files[@]}"
-          exit "$rc"
+          shellcheck .github/scripts/verify-apply.sh
+          .github/scripts/verify-apply.sh "$GITHUB_WORKSPACE"
 
   data-syntax:
     name: data syntax (.chezmoidata)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,118 @@ jobs:
           done
           shellcheck "$tmpdir"/*.sh
 
+      # 属性プレフィックス (create_ / executable_ など) の誤りや .chezmoiignore の
+      # パターンずれはテンプレート展開では捕まらないので、実際に apply して確かめる。
+      # スクリプトは brew install などの副作用を伴うため --exclude scripts で外す
+      # (スクリプト本文の検証は上の shellcheck が担当する)。
+      # 配置先は使い捨ての一時ディレクトリで、ランナーの $HOME には触らない
+      - name: Verify chezmoi apply
+        run: |
+          dest="$(mktemp -d)"
+          echo "APPLY_DEST=$dest" >> "$GITHUB_ENV"
+          chezmoi apply --source "$GITHUB_WORKSPACE" --destination "$dest" --exclude scripts
+          # 冪等性の確認。apply 済みの配置先に対して status が何か報告するなら、
+          # 展開結果が非決定的か、書けていないエントリがある
+          st="$(chezmoi status --source "$GITHUB_WORKSPACE" --destination "$dest" --exclude scripts)"
+          if [ -n "$st" ]; then
+            printf 'NG: apply 後も status が差分を報告する\n%s\n' "$st" >&2
+            exit 1
+          fi
+          echo "OK: chezmoi apply --destination $dest"
+
+      - name: Verify applied attributes and .chezmoiignore
+        run: |
+          rc=0
+
+          # executable_ が実行ビットになっているか。ソース名から配置先への変換は
+          # chezmoi 自身に解決させ、プレフィックスの規則を CI 側に複製しない
+          while IFS= read -r src; do
+            tgt="$(chezmoi target-path --source "$GITHUB_WORKSPACE" \
+                     --destination "$APPLY_DEST" "$src")"
+            if [ -x "$tgt" ]; then
+              echo "OK: executable $src"
+            else
+              echo "NG: 実行ビットが立っていない $src -> $tgt" >&2
+              rc=1
+            fi
+          done < <(find . -path ./.git -prune -o -type f -name '*executable_*' -print | sort)
+
+          # 属性プレフィックスの綴りを間違えると (creat_ / exectuable_ など) chezmoi は
+          # ただの名前として扱い、そのまま配置先のファイル名に残る。配置後の名前が
+          # `xxx_` で始まっていたらこれを疑う (正当な配置先に該当する名前は無い)
+          while IFS= read -r -d '' f; do
+            if [[ "$(basename "$f")" =~ ^[a-z]+_ ]]; then
+              echo "NG: 属性プレフィックスの綴り間違いに見える: ${f#"$APPLY_DEST"/}" >&2
+              rc=1
+            fi
+          done < <(find "$APPLY_DEST" -mindepth 1 -print0)
+
+          # .chezmoiignore に書いたリポジトリ用のファイルが配置されていないこと
+          for f in README.md CLAUDE.md; do
+            if [ -e "$APPLY_DEST/$f" ]; then
+              echo "NG: .chezmoiignore で除外したはずの $f が配置された" >&2
+              rc=1
+            else
+              echo "OK: ignored $f"
+            fi
+          done
+
+          # 06 は darwin 限定。.chezmoiignore のパターンはソース名ではなく展開後の
+          # ターゲット名で書く必要があり、間違えても静かに無視されるので managed で見る
+          # (grep -q にパイプで渡すと pipefail 下で上流が SIGPIPE で落ちうるので、
+          # いったん変数に受けてから照合する)
+          target=".chezmoiscripts/06_check_1password_ssh_agent.sh"
+          scripts="$(chezmoi managed --source "$GITHUB_WORKSPACE" \
+                       --destination "$APPLY_DEST" --include=scripts)"
+          if grep -qxF "$target" <<< "$scripts"; then
+            managed=yes
+          else
+            managed=no
+          fi
+          if [ "$RUNNER_OS" = macOS ]; then
+            want=yes
+          else
+            want=no
+          fi
+          if [ "$managed" = "$want" ]; then
+            echo "OK: $target managed=$managed ($RUNNER_OS)"
+          else
+            echo "NG: $target が $RUNNER_OS で managed=$managed (期待は $want)" >&2
+            rc=1
+          fi
+
+          exit "$rc"
+
+      # テンプレートでない生のシェルスクリプト (dot_config/borders/executable_bordersrc
+      # など) は rendered .chezmoiscripts の shellcheck では拾えない。配置結果を走査して
+      # shebang が sh / bash のものを対象にする (zsh は shellcheck が扱えないので除く)
+      - name: Shellcheck applied shell scripts
+        run: |
+          files=()
+          while IFS= read -r -d '' f; do
+            case "$(head -n 1 "$f")" in
+              '#!'*/sh | '#!'*/sh\ * | '#!'*/bash | '#!'*/bash\ * | \
+                '#!'*env\ sh* | '#!'*env\ bash*)
+                files+=("$f")
+                ;;
+            esac
+          done < <(find "$APPLY_DEST" -type f -print0)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "NG: shebang 付きのシェルスクリプトが 1 つも見つからない (走査が壊れている?)" >&2
+            exit 1
+          fi
+          # shebang があるのに実行できない = ソース側で executable_ の付け忘れ
+          rc=0
+          for f in "${files[@]}"; do
+            [ -x "$f" ] || {
+              echo "NG: shebang 付きだが実行ビットが無い: ${f#"$APPLY_DEST"/} (executable_ の付け忘れ?)" >&2
+              rc=1
+            }
+          done
+          printf 'checking: %s\n' "${files[@]}"
+          shellcheck "${files[@]}"
+          exit "$rc"
+
   data-syntax:
     name: data syntax (.chezmoidata)
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,14 +6,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 [chezmoi](https://www.chezmoi.io/) で管理する dotfiles のソースディレクトリ。ビルドは存在しないが、CI (`.github/workflows/ci.yml`) が macOS (arm64/amd64) と Ubuntu の各ランナーで全テンプレート (`*.tmpl` と `.chezmoiignore` / `.chezmoiremove`) の `chezmoi execute-template` 検証・展開後スクリプトの shellcheck・`.chezmoidata` のデータ構文チェックに加え、使い捨ての一時ディレクトリへの `chezmoi apply` (`--exclude scripts`) まで行う。対象 OS は macOS (Intel / Apple Silicon) と Ubuntu で、OS 差分は Go テンプレートで吸収する。
 
-apply まで回すのは、属性プレフィックス (`create_` / `executable_`) の誤りや `.chezmoiignore` のパターンずれがテンプレート展開では捕まらないため。apply の結果に対して CI が見ているのは次の 4 点:
+apply まで回すのは、属性プレフィックス (`create_` / `executable_`) の誤りや `.chezmoiignore` のパターンずれがテンプレート展開では捕まらないため。実体は `.github/scripts/verify-apply.sh` で、何をどういう理由で見ているかはそのスクリプトのコメントに書いてある。**引数なしで手元から実行できる** (配置先は毎回 `mktemp -d` なので `$HOME` には触らない) ので、CI が落ちたらまずこれを走らせる。
 
-- 2 回目の `chezmoi status` が空 (冪等性。展開が非決定的だったり配置できないエントリがあると出る)
-- `executable_` 付きのソースが実行ビット付きで配置されている。逆向きに、配置後に shebang を持つファイルが実行可能であること (= `executable_` の付け忘れ) も見る
-- 配置後のファイル名が `xxx_` で始まっていない (プレフィックスの綴りを間違えると chezmoi はただの名前として扱い、そのまま配置先に残る)
-- `.chezmoiignore` が効いている (`README.md` / `CLAUDE.md` が配置されない、06 のスクリプトが darwin でだけ managed)
-
-あわせて、配置後のツリーから shebang が sh / bash のファイルを拾って shellcheck にかける。`.tmpl` でない生のシェルスクリプト (`dot_config/borders/executable_bordersrc`) はこちらで拾われる。
+```sh
+.github/scripts/verify-apply.sh
+```
 
 このディレクトリ自体が chezmoi のソースディレクトリ (`~/.local/share/chezmoi`) なので、ここでファイルを編集しても `chezmoi apply` するまでホームディレクトリには反映されない。
 
@@ -112,7 +109,7 @@ Go / Node / Ruby / uv などのランタイムは mise に一本化しており�
 
 代わりに `run_after_06_check_1password_ssh_agent.sh.tmpl` が apply のたびに agent.sock の有無を見て、無効なら有効化手順を stderr に出す。有効なら無音、どのケースでも `exit 0` で apply は止めない。`run_once_` にしないのは、初回 apply の時点ではまだサインインが済んでおらず、一度きりの警告だと有効化し忘れたまま気づけなくなるため。
 
-このスクリプトだけ **darwin 限定の方法が他と違う**。他のスクリプトはテンプレートの `{{ if eq .chezmoi.os "darwin" }}` で本文を空にしているが、これは毎回走る `run_after_` なので、それだと Linux で apply のたびに空のプロセスが起きる。代わりに `.chezmoiignore` でスクリプトごと除外している。**`.chezmoiignore` に書くパターンはソース名ではなく展開後のターゲット名** (`.chezmoiscripts/06_check_1password_ssh_agent.sh`) で、ソース名を書いても一致せず静かに無視される。効いているかは `chezmoi managed --include=scripts` で確認できる (CI もこのコマンドで、darwin でだけ managed になることをアサートしている)。
+このスクリプトだけ **darwin 限定の方法が他と違う**。他のスクリプトはテンプレートの `{{ if eq .chezmoi.os "darwin" }}` で本文を空にしているが、これは毎回走る `run_after_` なので、それだと Linux で apply のたびに空のプロセスが起きる。代わりに `.chezmoiignore` でスクリプトごと除外している。**`.chezmoiignore` に書くパターンはソース名ではなく展開後のターゲット名** (`.chezmoiscripts/06_check_1password_ssh_agent.sh`) で、ソース名を書いても一致せず静かに無視される。効いているかは `chezmoi managed --include=scripts` で確認できる。`chezmoi ignored` を使うともっと直接的で、**実在するエントリを実際に抑止したパターンしか出てこない**ので、ソース名で書いてしまったパターンは一覧から消える。CI (`.github/scripts/verify-apply.sh`) はこの性質を使って、OS ごとの ignored 一覧が想定と一致することをアサートしている。
 
 ## 変更時の注意
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,16 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## リポジトリの性質
 
-[chezmoi](https://www.chezmoi.io/) で管理する dotfiles のソースディレクトリ。ビルドは存在しないが、CI (`.github/workflows/ci.yml`) が macOS (arm64/amd64) と Ubuntu の各ランナーで全テンプレート (`*.tmpl` と `.chezmoiignore` / `.chezmoiremove`) の `chezmoi execute-template` 検証・展開後スクリプトの shellcheck・`.chezmoidata` のデータ構文チェックを行う。対象 OS は macOS (Intel / Apple Silicon) と Ubuntu で、OS 差分は Go テンプレートで吸収する。
+[chezmoi](https://www.chezmoi.io/) で管理する dotfiles のソースディレクトリ。ビルドは存在しないが、CI (`.github/workflows/ci.yml`) が macOS (arm64/amd64) と Ubuntu の各ランナーで全テンプレート (`*.tmpl` と `.chezmoiignore` / `.chezmoiremove`) の `chezmoi execute-template` 検証・展開後スクリプトの shellcheck・`.chezmoidata` のデータ構文チェックに加え、使い捨ての一時ディレクトリへの `chezmoi apply` (`--exclude scripts`) まで行う。対象 OS は macOS (Intel / Apple Silicon) と Ubuntu で、OS 差分は Go テンプレートで吸収する。
+
+apply まで回すのは、属性プレフィックス (`create_` / `executable_`) の誤りや `.chezmoiignore` のパターンずれがテンプレート展開では捕まらないため。apply の結果に対して CI が見ているのは次の 4 点:
+
+- 2 回目の `chezmoi status` が空 (冪等性。展開が非決定的だったり配置できないエントリがあると出る)
+- `executable_` 付きのソースが実行ビット付きで配置されている。逆向きに、配置後に shebang を持つファイルが実行可能であること (= `executable_` の付け忘れ) も見る
+- 配置後のファイル名が `xxx_` で始まっていない (プレフィックスの綴りを間違えると chezmoi はただの名前として扱い、そのまま配置先に残る)
+- `.chezmoiignore` が効いている (`README.md` / `CLAUDE.md` が配置されない、06 のスクリプトが darwin でだけ managed)
+
+あわせて、配置後のツリーから shebang が sh / bash のファイルを拾って shellcheck にかける。`.tmpl` でない生のシェルスクリプト (`dot_config/borders/executable_bordersrc`) はこちらで拾われる。
 
 このディレクトリ自体が chezmoi のソースディレクトリ (`~/.local/share/chezmoi`) なので、ここでファイルを編集しても `chezmoi apply` するまでホームディレクトリには反映されない。
 
@@ -103,7 +112,7 @@ Go / Node / Ruby / uv などのランタイムは mise に一本化しており�
 
 代わりに `run_after_06_check_1password_ssh_agent.sh.tmpl` が apply のたびに agent.sock の有無を見て、無効なら有効化手順を stderr に出す。有効なら無音、どのケースでも `exit 0` で apply は止めない。`run_once_` にしないのは、初回 apply の時点ではまだサインインが済んでおらず、一度きりの警告だと有効化し忘れたまま気づけなくなるため。
 
-このスクリプトだけ **darwin 限定の方法が他と違う**。他のスクリプトはテンプレートの `{{ if eq .chezmoi.os "darwin" }}` で本文を空にしているが、これは毎回走る `run_after_` なので、それだと Linux で apply のたびに空のプロセスが起きる。代わりに `.chezmoiignore` でスクリプトごと除外している。**`.chezmoiignore` に書くパターンはソース名ではなく展開後のターゲット名** (`.chezmoiscripts/06_check_1password_ssh_agent.sh`) で、ソース名を書いても一致せず静かに無視される。効いているかは `chezmoi managed --include=scripts` で確認できる。
+このスクリプトだけ **darwin 限定の方法が他と違う**。他のスクリプトはテンプレートの `{{ if eq .chezmoi.os "darwin" }}` で本文を空にしているが、これは毎回走る `run_after_` なので、それだと Linux で apply のたびに空のプロセスが起きる。代わりに `.chezmoiignore` でスクリプトごと除外している。**`.chezmoiignore` に書くパターンはソース名ではなく展開後のターゲット名** (`.chezmoiscripts/06_check_1password_ssh_agent.sh`) で、ソース名を書いても一致せず静かに無視される。効いているかは `chezmoi managed --include=scripts` で確認できる (CI もこのコマンドで、darwin でだけ managed になることをアサートしている)。
 
 ## 変更時の注意
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 [chezmoi](https://www.chezmoi.io/) で管理する dotfiles のソースディレクトリ。ビルドは存在しないが、CI (`.github/workflows/ci.yml`) が macOS (arm64/amd64) と Ubuntu の各ランナーで全テンプレート (`*.tmpl` と `.chezmoiignore` / `.chezmoiremove`) の `chezmoi execute-template` 検証・展開後スクリプトの shellcheck・`.chezmoidata` のデータ構文チェックに加え、使い捨ての一時ディレクトリへの `chezmoi apply` (`--exclude scripts`) まで行う。対象 OS は macOS (Intel / Apple Silicon) と Ubuntu で、OS 差分は Go テンプレートで吸収する。
 
-apply まで回すのは、属性プレフィックス (`create_` / `executable_`) の誤りや `.chezmoiignore` のパターンずれがテンプレート展開では捕まらないため。実体は `.github/scripts/verify-apply.sh` で、何をどういう理由で見ているかはそのスクリプトのコメントに書いてある。**引数なしで手元から実行できる** (配置先は毎回 `mktemp -d` なので `$HOME` には触らない) ので、CI が落ちたらまずこれを走らせる。
+apply まで回すのは、属性プレフィックス (`create_` / `executable_`) の誤りや `.chezmoiignore` のパターンずれがテンプレート展開では捕まらないため。実体は `.github/scripts/verify-apply.sh` で、何をどういう理由で見ているかはそのスクリプトのコメントに書いてある。**引数なしで手元から実行できる**ので、CI が落ちたらまずこれを走らせる。配置先だけでなく chezmoi.toml と永続ステートも使い捨ての一時ディレクトリに作る (`--config` / `--persistent-state`) ので、`$HOME` の状態には触らないし、`chezmoi init` していないクローンでも CI と同じ条件で回る。
+
+**`--destination` だけでは `$HOME` から切り離せない**点に注意。永続ステート (`~/.config/chezmoi/chezmoistate.boltdb`) の参照先は変わらないままなので、`--persistent-state` も一緒に渡す必要がある。
 
 ```sh
 .github/scripts/verify-apply.sh


### PR DESCRIPTION
Closes #65

## 変更

`verify` ジョブ (macOS arm64 / macOS Intel / Ubuntu) に、使い捨ての一時ディレクトリへの `chezmoi apply` とその結果に対するアサーションを追加した。ランナーの `$HOME` には触れず、副作用のあるスクリプトは `--exclude scripts` で外している。

検査の実体は [`.github/scripts/verify-apply.sh`](.github/scripts/verify-apply.sh) に置いた。ワークフローは shellcheck をかけてこれを呼ぶだけ。**引数なしで手元からも実行できる**ので、CI が落ちたときに同じものをそのまま再現できる。

```sh
.github/scripts/verify-apply.sh
```

見ているのは 4 点:

- `chezmoi apply` が成功し、続く `chezmoi status` が空 (冪等性)
- `chezmoi ignored` の一覧が OS ごとの想定と一致する。`ignored` が挙げるのは**実在するエントリを実際に抑止したパターンだけ**なので、issue が言う「`.chezmoiignore` にソース名を書いても静かに無視される」をこの一覧の欠落として検出できる
- 配置後のファイル名が `xxx_` で始まっていない。プレフィックスの綴りを間違えると chezmoi はただの名前として扱い、そのまま配置先に残るため
- 配置後に shebang を持つファイルが実行可能である (= `executable_` の付け忘れ)。あわせてそれらを shellcheck にかけるので、`.tmpl` でない生シェルスクリプト (`dot_config/borders/executable_bordersrc`) が初めて検査対象に入る

## 確認

意図的に壊したソースのコピーに対して、それぞれ期待どおり `exit 1` することを確認済み:

| 壊し方 | 検出 |
| --- | --- |
| `executable_` → `exectuable_`、`create_` → `creat_` | 綴り間違い + 実行ビット |
| `.chezmoiignore` の `README.md` → `readme.md` | `ignored` 一覧の欠落 |
| `executable_` を落とす | 実行ビット |

macOS の `/bin/bash` (3.2) でも動くことを確認した。CI は 3 ランナーとも green で、`ignored` チェックは Darwin / Linux 両分岐が実際に通っている。