### PR TITLE
git のコミット署名プログラムを macOS で無条件に設定する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,7 +108,7 @@ Go / Node / Ruby / uv などのランタイムは mise に一本化しており�
 
 - インストール: `.chezmoidata/packages.yaml` の cask (`1password` / `1password-cli`) で入る
 - SSH agent: `dot_config/zsh/dot_zshenv.tmpl` で `SSH_AUTH_SOCK` を 1Password の agent.sock に向けている (darwin のみ)。ソケットのパスは `.chezmoidata/onepassword.yaml` が唯一の情報源で、zshenv と後述のチェックスクリプトの両方がここを参照する
-- コミット署名: `dot_config/git/config.tmpl` で `gpg.format = ssh` + `commit.gpgsign = true`。署名プログラムは `op` コマンドが存在する macOS でのみ `op-ssh-sign` を設定する条件付きブロックになっている (Linux では署名プログラム未設定)
+- コミット署名: `dot_config/git/config.tmpl` で `gpg.format = ssh` + `commit.gpgsign = true`。署名プログラム (`op-ssh-sign`) は macOS なら**無条件で**設定する (Linux では未設定)。`op-ssh-sign` は CLI ではなく 1Password.app の同梱物なので `lookPath "op"` で分岐しない。インストール済みかどうかも見ない — ファイルの配置は brew bundle (`run_once_after_02`) より前に走るため、初回 apply では必ず「未インストール」と判定され、`gpgsign = true` だけが効いた署名できない状態になるため。アプリが無いケースの案内は `run_after_06_check_1password_ssh_agent` が毎回の apply で出す
 
 **SSH agent の有効化そのものは自動化していない。** トグルの実体は 1Password の `settings.json` (`sshAgent.enabled`) だが、初回サインインを済ませるまでこのファイルが存在せず (サインインは GUI 必須)、アプリ起動中の書き換えはメモリ上の状態に上書きされ、かつ非公式フォーマットなのでキー名がアップデートで黙って変わりうる。
 

--- a/dot_config/git/config.tmpl
+++ b/dot_config/git/config.tmpl
@@ -22,7 +22,15 @@
 [commit]
   gpgsign = true
 
-{{ if (and (lookPath "op") (eq .chezmoi.os "darwin")) }}
+{{ if eq .chezmoi.os "darwin" -}}
+{{/*
+  op-ssh-sign は 1Password.app の同梱物なので、CLI (op) の有無で分岐しない。
+  インストール状況も見ない: ファイルの配置は brew bundle (run_once_after_02) より
+  前に走るため、初回 apply では必ず「まだ入っていない」と判定されてしまい、
+  gpgsign = true だけが有効な状態 (= 署名できずコミットが失敗する) になる。
+  アプリが無ければどのみち署名できないし、その案内は
+  run_after_06_check_1password_ssh_agent が毎回の apply でやっている。
+*/ -}}
 [gpg "ssh"]
   program = /Applications/1Password.app/Contents/MacOS/op-ssh-sign
 {{ end }}


### PR DESCRIPTION
Closes #62

## 変更内容

`dot_config/git/config.tmpl` の `[gpg "ssh"] program` の条件を
`and (lookPath "op") (eq .chezmoi.os "darwin")` → `eq .chezmoi.os "darwin"` に変更し、
macOS では無条件に `op-ssh-sign` を設定するようにした。

## なぜ

- `lookPath "op"` は CLI (`1password-cli`) を見ているが、設定する `op-ssh-sign` は
  デスクトップアプリ (1Password.app) の同梱物なので判定として誤り
- issue の代替案にある `stat "/Applications/1Password.app"` も、ファイルの配置が
  brew bundle (`run_once_after_02`) より前に走る以上、初回 apply では必ず false になり
  「2 回目の apply までコミットが署名エラーで失敗する」問題は解決しない
- アプリが無い場合の案内は `run_after_06_check_1password_ssh_agent` が毎回の apply で
  出しているので、判定を省いても気づけなくなることはない

判断の根拠はテンプレート内のコメントと CLAUDE.md に残した。

## 確認

- `chezmoi execute-template < dot_config/git/config.tmpl` で darwin 側の展開結果に
  `[gpg "ssh"] program = ...` が出ることを確認
- Linux 側の展開は手元 (macOS) では再現できないため CI の ubuntu ランナー待ち。
  分岐は単純な `if` なのでブロックごと省略される

🤖 Generated with [Claude Code](https://claude.com/claude-code)